### PR TITLE
Added correlated chi2, solved some extrapolating problems

### DIFF
--- a/L1Trigger/DTPhase2Trigger/interface/analtypedefs.h
+++ b/L1Trigger/DTPhase2Trigger/interface/analtypedefs.h
@@ -25,20 +25,28 @@ struct metaPrimitive
   int quality;
   int wi1;
   int tdc1;
+  int lat1;
   int wi2;
   int tdc2;
+  int lat2;
   int wi3;
   int tdc3;
+  int lat3;
   int wi4;
   int tdc4;
+  int lat4;
   int wi5;
   int tdc5;
+  int lat5;
   int wi6;
   int tdc6;
+  int lat6;
   int wi7;
   int tdc7;
+  int lat7;
   int wi8;
   int tdc8;
+  int lat8;
 };
 typedef struct {
   bool latQValid;

--- a/L1Trigger/DTPhase2Trigger/src/MuonPathAnalyzerPerSL.cc
+++ b/L1Trigger/DTPhase2Trigger/src/MuonPathAnalyzerPerSL.cc
@@ -135,12 +135,12 @@ void MuonPathAnalyzerPerSL::analyze(MuonPath *inMPath,std::vector<metaPrimitive>
     if(debug) std::cout<<"DTp2:analyze \t\t\t\t\t no it is NOT analyzable "<<mPath->isAnalyzable()<<std::endl;
   }
   
-  int wi[8],tdc[8];
+  int wi[8],tdc[8],lat[8];
   DTPrimitive Prim0(mPath->getPrimitive(0)); wi[0]=Prim0.getChannelId();tdc[0]=Prim0.getTDCTime();
   DTPrimitive Prim1(mPath->getPrimitive(1)); wi[1]=Prim1.getChannelId();tdc[1]=Prim1.getTDCTime();
   DTPrimitive Prim2(mPath->getPrimitive(2)); wi[2]=Prim2.getChannelId();tdc[2]=Prim2.getTDCTime();
   DTPrimitive Prim3(mPath->getPrimitive(3)); wi[3]=Prim3.getChannelId();tdc[3]=Prim3.getTDCTime();
-  for(int i=4;i<8;i++){wi[i]=-1;tdc[i]=-1;}
+  for(int i=4;i<8;i++){wi[i]=-1;tdc[i]=-1;lat[i]=-1;}
 
   DTWireId wireId(MuonPathSLId,2,1);
   
@@ -161,6 +161,7 @@ void MuonPathAnalyzerPerSL::analyze(MuonPath *inMPath,std::vector<metaPrimitive>
     double chi2_phiB=-1;
     double chi2_chi2=-1;
     int chi2_quality=-1;
+    int bestLat[8]; for (int i = 0; i < 8; i++) {bestLat[i] = -1; }
     
     for (int i = 0; i < totalNumValLateralities; i++) {//here
       if(debug) std::cout<<"DTp2:analyze \t\t\t\t\t laterality #- "<<i<<std::endl;
@@ -177,10 +178,15 @@ void MuonPathAnalyzerPerSL::analyze(MuonPath *inMPath,std::vector<metaPrimitive>
 	mPath->setBxTimeValue(latQuality[i].bxValue);
 	if(debug) std::cout<<"DTp2:analyze \t\t\t\t\t laterality #- "<<i<<" settingLateralCombination"<<std::endl;
 	mPath->setLateralComb(lateralities[i]);
+
 	if(debug) std::cout<<"DTp2:analyze \t\t\t\t\t laterality #- "<<i<<" done settingLateralCombination"<<std::endl;
 	
 	// Clonamos el objeto analizado.
 	MuonPath *mpAux = new MuonPath(mPath);
+	lat[0] = mpAux->getLateralComb()[0];
+        lat[1] = mpAux->getLateralComb()[1];
+        lat[2] = mpAux->getLateralComb()[2];
+        lat[3] = mpAux->getLateralComb()[3];
 	
 	int idxHitNotValid = latQuality[i].invalidateHitIdx;
 	if (idxHitNotValid >= 0) {
@@ -254,18 +260,19 @@ void MuonPathAnalyzerPerSL::analyze(MuonPath *inMPath,std::vector<metaPrimitive>
 	      chi2_phiB=phiB;
 	      chi2_chi2=chi2;
 	      chi2_quality= mpAux->getQuality();
+	      for (int iter = 0; iter < 4; iter++) {bestLat[iter] = lat[iter]; }
 	    }
 	  }else{//write the metaprimitive in case no HIGHQ or HIGHQGHOST
 	    if(debug) std::cout<<"DTp2:analyze \t\t\t\t\t\t\t\t  pushing back metaprimitive no HIGHQ or HIGHQGHOST"<<std::endl;
 	    metaPrimitives.push_back(metaPrimitive({MuonPathSLId.rawId(),jm_t0,jm_x,jm_tanPhi,phi,phiB,chi2,quality,
-		    wi[0],tdc[0],
-		    wi[1],tdc[1],
-		    wi[2],tdc[2],
-		    wi[3],tdc[3],
-		    wi[4],tdc[4],
-		    wi[5],tdc[5],
-		    wi[6],tdc[6],
-		    wi[7],tdc[7]
+		    wi[0],tdc[0],lat[0],
+		    wi[1],tdc[1],lat[1],
+		    wi[2],tdc[2],lat[2],
+		    wi[3],tdc[3],lat[3],
+		    wi[4],tdc[4],lat[4],
+		    wi[5],tdc[5],lat[5],
+		    wi[6],tdc[6],lat[6],
+		    wi[7],tdc[7],lat[7]
 		    }));
 	    if(debug) std::cout<<"DTp2:analyze \t\t\t\t\t\t\t\t  done pushing back metaprimitive no HIGHQ or HIGHQGHOST"<<std::endl;	
 	  }				
@@ -279,14 +286,14 @@ void MuonPathAnalyzerPerSL::analyze(MuonPath *inMPath,std::vector<metaPrimitive>
     if(chi2_jm_tanPhi!=999){//
       if(debug) std::cout<<"DTp2:analyze \t\t\t\t\t\t\t\t  pushing back best chi2 metaPrimitive"<<std::endl;
       metaPrimitives.push_back(metaPrimitive({MuonPathSLId.rawId(),chi2_jm_t0,chi2_jm_x,chi2_jm_tanPhi,chi2_phi,chi2_phiB,chi2_chi2,chi2_quality,
-	      wi[0],tdc[0],
-	      wi[1],tdc[1],
-	      wi[2],tdc[2],
-	      wi[3],tdc[3],
-	      wi[4],tdc[4],
-	      wi[5],tdc[5],
-	      wi[6],tdc[6],
-	      wi[7],tdc[7]
+	      wi[0],tdc[0],bestLat[0],
+	      wi[1],tdc[1],bestLat[1],
+	      wi[2],tdc[2],bestLat[2],
+	      wi[3],tdc[3],bestLat[3],
+	      wi[4],tdc[4],bestLat[4],
+	      wi[5],tdc[5],bestLat[5],
+	      wi[6],tdc[6],bestLat[6],
+	      wi[7],tdc[7],bestLat[7],
 	      }));
     }
   }

--- a/L1Trigger/DTPhase2Trigger/src/MuonPathAssociator.cc
+++ b/L1Trigger/DTPhase2Trigger/src/MuonPathAssociator.cc
@@ -111,7 +111,34 @@ void MuonPathAssociator::correlateMPaths(edm::Handle<DTDigiCollection> dtdigis,
 	      double NewSlope=(PosSL1-PosSL3)/23.5;     
 	      double MeanT0=(SL1metaPrimitive->t0+SL3metaPrimitive->t0)/2;
 	      double MeanPos=(PosSL3+PosSL1)/2;
-	      double newChi2=(SL1metaPrimitive->chi2+SL3metaPrimitive->chi2)*0.5;//to be recalculated
+		
+	      DTSuperLayerId SLId1(SL1metaPrimitive->rawId);
+              DTSuperLayerId SLId3(SL3metaPrimitive->rawId);
+
+              DTWireId wireId1(SLId1,2,1);
+              DTWireId wireId3(SLId3,2,1);
+
+              double x1 = shiftinfo[wireId1.rawId()]+(42.*SL1metaPrimitive->wi1+21. + (21./386.74)*(SL1metaPrimitive->tdc1-MeanT0)*(-1+2*SL1metaPrimitive->lat1))/10;
+              double x2 = shiftinfo[wireId1.rawId()]+(42.*SL1metaPrimitive->wi2+(21./386.74)*(SL1metaPrimitive->tdc2-MeanT0)*(-1+2*SL1metaPrimitive->lat2))/10;
+              double x3 = shiftinfo[wireId1.rawId()]+(42.*SL1metaPrimitive->wi3+21. + (21./386.74)*(SL1metaPrimitive->tdc3-MeanT0)*(-1+2*SL1metaPrimitive->lat3))/10;
+              double x4 = shiftinfo[wireId1.rawId()]+(42.*SL1metaPrimitive->wi4+(21./386.74)*(SL1metaPrimitive->tdc4-MeanT0)*(-1+2*SL1metaPrimitive->lat4))/10;
+              double x5 = shiftinfo[wireId3.rawId()]+(42.*SL3metaPrimitive->wi1+21. + (21./386.74)*(SL3metaPrimitive->tdc1-MeanT0)*(-1+2*SL3metaPrimitive->lat1))/10;
+              double x6 = shiftinfo[wireId3.rawId()]+(42.*SL3metaPrimitive->wi2+(21./386.74)*(SL3metaPrimitive->tdc2-MeanT0)*(-1+2*SL3metaPrimitive->lat2))/10;
+              double x7 = shiftinfo[wireId3.rawId()]+(42.*SL3metaPrimitive->wi3+21. + (21./386.74)*(SL3metaPrimitive->tdc3-MeanT0)*(-1+2*SL3metaPrimitive->lat3))/10;
+              double x8 = shiftinfo[wireId3.rawId()]+(42.*SL3metaPrimitive->wi4+(21./386.74)*(SL3metaPrimitive->tdc4-MeanT0)*(-1+2*SL3metaPrimitive->lat4))/10;
+
+              double x1reco = MeanPos+(23.5/2 - (1-2.5)*1.3)*NewSlope;
+              double x2reco = MeanPos+(23.5/2 - (2-2.5)*1.3)*NewSlope;
+              double x3reco = MeanPos+(23.5/2 - (3-2.5)*1.3)*NewSlope;
+              double x4reco = MeanPos+(23.5/2 - (4-2.5)*1.3)*NewSlope;
+              double x5reco = MeanPos+(-23.5/2 - (1-2.5)*1.3)*NewSlope;
+              double x6reco = MeanPos+(-23.5/2 - (2-2.5)*1.3)*NewSlope;
+              double x7reco = MeanPos+(-23.5/2 - (3-2.5)*1.3)*NewSlope;
+              double x8reco = MeanPos+(-23.5/2 - (4-2.5)*1.3)*NewSlope;
+
+
+              double newChi2 = (x1reco-x1)*(x1reco-x1)+(x2reco-x2)*(x2reco-x2)+(x3reco-x3)*(x3reco-x3)+(x4reco-x4)*(x4reco-x4)+(x5reco-x5)*(x5reco-x5)+(x6reco-x6)*(x6reco-x6)+(x7reco-x7)*(x7reco-x7)+(x8reco-x8)*(x8reco-x8);
+
 	      int quality = 0;
 	      if(SL3metaPrimitive->quality <= 2 and SL1metaPrimitive->quality <=2) quality=6;
 	      
@@ -129,14 +156,14 @@ void MuonPathAssociator::correlateMPaths(edm::Handle<DTDigiCollection> dtdigis,
 	      double phiB=hasPosRF(ChId.wheel(),ChId.sector()) ? psi-phi :-psi-phi ;
 	      
 	      outMPaths.push_back(metaPrimitive({ChId.rawId(),MeanT0,MeanPos,NewSlope,phi,phiB,newChi2,quality,
-		      SL1metaPrimitive->wi1,SL1metaPrimitive->tdc1,
-		      SL1metaPrimitive->wi2,SL1metaPrimitive->tdc2,
-		      SL1metaPrimitive->wi3,SL1metaPrimitive->tdc3,
-		      SL1metaPrimitive->wi4,SL1metaPrimitive->tdc4,
-		      SL3metaPrimitive->wi1,SL3metaPrimitive->tdc1,
-		      SL3metaPrimitive->wi2,SL3metaPrimitive->tdc2,
-		      SL3metaPrimitive->wi3,SL3metaPrimitive->tdc3,
-		      SL3metaPrimitive->wi4,SL3metaPrimitive->tdc4
+		      SL1metaPrimitive->wi1,SL1metaPrimitive->tdc1,SL1metaPrimitive->lat1,
+		      SL1metaPrimitive->wi2,SL1metaPrimitive->tdc2,SL1metaPrimitive->lat2,
+		      SL1metaPrimitive->wi3,SL1metaPrimitive->tdc3,SL1metaPrimitive->lat3,
+		      SL1metaPrimitive->wi4,SL1metaPrimitive->tdc4,SL1metaPrimitive->lat4,
+		      SL3metaPrimitive->wi1,SL3metaPrimitive->tdc1,SL3metaPrimitive->lat1,
+		      SL3metaPrimitive->wi2,SL3metaPrimitive->tdc2,SL3metaPrimitive->lat2,
+		      SL3metaPrimitive->wi3,SL3metaPrimitive->tdc3,SL3metaPrimitive->lat3,
+		      SL3metaPrimitive->wi4,SL3metaPrimitive->tdc4,SL3metaPrimitive->lat4,
 		      }));
 	      at_least_one_correlation=true;
 	    }
@@ -145,12 +172,16 @@ void MuonPathAssociator::correlateMPaths(edm::Handle<DTDigiCollection> dtdigis,
 	  if(at_least_one_correlation==false){//no correlation was found, trying with pairs of two digis in the other SL
 	    int matched_digis=0;
 	    double minx=minx_match_2digis;
+	    double min2x=minx_match_2digis;
 	    int best_tdc=-1;
 	    int next_tdc=-1;
 	    int best_wire=-1;
 	    int next_wire=-1;
+	    int best_lat=-1;
+	    int next_lat=-1;
 	    int best_layer=-1;
 	    int next_layer=-1;
+	    int lat=-1;
 	    
 	    for (auto dtLayerId_It=dtdigis->begin(); dtLayerId_It!=dtdigis->end(); ++dtLayerId_It){
 	      const DTLayerId dtLId = (*dtLayerId_It).first;
@@ -166,17 +197,30 @@ void MuonPathAssociator::correlateMPaths(edm::Handle<DTDigiCollection> dtdigis,
 		DTWireId wireId(dtLId,(*digiIt).wire());
 		int x_wire = shiftinfo[wireId.rawId()]+((*digiIt).time()-SL1metaPrimitive->t0)*0.00543; 
 		int x_wire_left = shiftinfo[wireId.rawId()]-((*digiIt).time()-SL1metaPrimitive->t0)*0.00543; 
-		if(fabs(x_inSL3-x_wire)>fabs(x_inSL3-x_wire_left)) x_wire=x_wire_left; //choose the closest laterality
+		lat=1; 
+		if(fabs(x_inSL3-x_wire)>fabs(x_inSL3-x_wire_left)){
+	          x_wire=x_wire_left; //choose the closest laterality
+		  lat=0;
+		}
 		if(fabs(x_inSL3-x_wire)<minx){
 		  minx=fabs(x_inSL3-x_wire);
 		  next_wire=best_wire;
 		  next_tdc=best_tdc;
 		  next_layer=best_layer;
+		  next_lat=best_lat;
 		  
 		  best_wire=(*digiIt).wire();
 		  best_tdc=(*digiIt).time();
 		  best_layer=dtLId.layer();
+		  best_lat=lat;
 		  matched_digis++;
+		} else if ((fabs(x_inSL3-x_wire)>minx)&&(fabs(x_inSL3-x_wire)<min2x)){
+		  min2x=fabs(x_inSL3-x_wire);
+		  next_wire=(*digiIt).wire();
+                  next_tdc=(*digiIt).time();
+                  next_layer=dtLId.layer();
+                  next_lat=lat;
+                  matched_digis++;
 		}
 	      }
 	      
@@ -185,33 +229,33 @@ void MuonPathAssociator::correlateMPaths(edm::Handle<DTDigiCollection> dtdigis,
 	      int new_quality=7;
 	      if(SL1metaPrimitive->quality<=2) new_quality=5;
 	      
-	      int wi1=-1;int tdc1=-1;
-	      int wi2=-1;int tdc2=-1;
-	      int wi3=-1;int tdc3=-1;
-	      int wi4=-1;int tdc4=-1;
+	      int wi1=-1;int tdc1=-1;int lat1=-1;
+	      int wi2=-1;int tdc2=-1;int lat2=-1;
+	      int wi3=-1;int tdc3=-1;int lat3=-1;
+	      int wi4=-1;int tdc4=-1;int lat4=-1;
 	      
-	      if(next_layer==1) {wi1=next_wire; tdc1=next_tdc; }
-	      if(next_layer==2) {wi2=next_wire; tdc2=next_tdc; }
-	      if(next_layer==3) {wi3=next_wire; tdc3=next_tdc; }
-	      if(next_layer==4) {wi4=next_wire; tdc4=next_tdc; }
+	      if(next_layer==1) {wi1=next_wire; tdc1=next_tdc; lat1 = next_lat;}
+	      if(next_layer==2) {wi2=next_wire; tdc2=next_tdc; lat2 = next_lat;}
+	      if(next_layer==3) {wi3=next_wire; tdc3=next_tdc; lat3 = next_lat;}
+	      if(next_layer==4) {wi4=next_wire; tdc4=next_tdc; lat4 = next_lat;}
 	      
-	      if(best_layer==1) {wi1=best_wire; tdc1=best_tdc; }
-	      if(best_layer==2) {wi2=best_wire; tdc2=best_tdc; }
-	      if(best_layer==3) {wi3=best_wire; tdc3=best_tdc; }
-	      if(best_layer==4) {wi4=best_wire; tdc4=best_tdc; } 
+	      if(best_layer==1) {wi1=best_wire; tdc1=best_tdc; lat1 = best_lat;}
+	      if(best_layer==2) {wi2=best_wire; tdc2=best_tdc; lat2 = next_lat;}
+	      if(best_layer==3) {wi3=best_wire; tdc3=best_tdc; lat3 = next_lat;}
+	      if(best_layer==4) {wi4=best_wire; tdc4=best_tdc; lat4 = next_lat;} 
 	      
 	      
 	      
 	      outMPaths.push_back(metaPrimitive({ChId.rawId(),SL1metaPrimitive->t0,SL1metaPrimitive->x,SL1metaPrimitive->tanPhi,SL1metaPrimitive->phi,SL1metaPrimitive->phiB,SL1metaPrimitive->chi2,
 		      new_quality,
-		      SL1metaPrimitive->wi1,SL1metaPrimitive->tdc1,
-		      SL1metaPrimitive->wi2,SL1metaPrimitive->tdc2,
-		      SL1metaPrimitive->wi3,SL1metaPrimitive->tdc3,
-		      SL1metaPrimitive->wi4,SL1metaPrimitive->tdc4,
-		      wi1,tdc1,
-		      wi2,tdc2,
-		      wi3,tdc3,
-		      wi4,tdc4
+		      SL1metaPrimitive->wi1,SL1metaPrimitive->tdc1,SL1metaPrimitive->lat1,
+		      SL1metaPrimitive->wi2,SL1metaPrimitive->tdc2,SL1metaPrimitive->lat2,
+		      SL1metaPrimitive->wi3,SL1metaPrimitive->tdc3,SL1metaPrimitive->lat3,
+		      SL1metaPrimitive->wi4,SL1metaPrimitive->tdc4,SL1metaPrimitive->lat4,
+		      wi1,tdc1,lat1,
+		      wi2,tdc2,lat2,
+		      wi3,tdc3,lat3,
+		      wi4,tdc4,lat4
 		      }));
 	      at_least_one_correlation=true;
 	    }
@@ -233,12 +277,16 @@ void MuonPathAssociator::correlateMPaths(edm::Handle<DTDigiCollection> dtdigis,
 	    
 	    int matched_digis=0;
 	    double minx=minx_match_2digis;
+	    double min2x=minx_match_2digis;
 	    int best_tdc=-1;
 	    int next_tdc=-1;
 	    int best_wire=-1;
 	    int next_wire=-1;
+	    int best_lat=-1;
+	    int next_lat=-1;
 	    int best_layer=-1;
 	    int next_layer=-1;
+	    int lat=-1;
 	    
 	    for (auto dtLayerId_It=dtdigis->begin(); dtLayerId_It!=dtdigis->end(); ++dtLayerId_It){
 	      const DTLayerId dtLId = (*dtLayerId_It).first;
@@ -254,18 +302,32 @@ void MuonPathAssociator::correlateMPaths(edm::Handle<DTDigiCollection> dtdigis,
 		DTWireId wireId(dtLId,(*digiIt).wire());
 		int x_wire = shiftinfo[wireId.rawId()]+((*digiIt).time()-SL3metaPrimitive->t0)*0.00543; 
 		int x_wire_left = shiftinfo[wireId.rawId()]-((*digiIt).time()-SL3metaPrimitive->t0)*0.00543; 
-		if(fabs(x_inSL1-x_wire)>fabs(x_inSL1-x_wire_left)) x_wire=x_wire_left; //choose the closest laterality
+		lat=1;
+		if(fabs(x_inSL1-x_wire)>fabs(x_inSL1-x_wire_left)){
+		  lat=0; 
+		  x_wire=x_wire_left; //choose the closest laterality
+		}
 		if(fabs(x_inSL1-x_wire)<minx){
 		  minx=fabs(x_inSL1-x_wire);
 		  next_wire=best_wire;
 		  next_tdc=best_tdc;
+		  next_lat=best_lat;
 		  next_layer=best_layer;
 		  
 		  best_wire=(*digiIt).wire();
 		  best_tdc=(*digiIt).time();
 		  best_layer=dtLId.layer();
+		  best_lat=lat;
 		  matched_digis++;
-		}
+		} else if ((fabs(x_inSL1-x_wire)>minx)&&(fabs(x_inSL1-x_wire)<min2x)){
+                  min2x=fabs(x_inSL1-x_wire);
+                  next_wire=(*digiIt).wire();
+                  next_tdc=(*digiIt).time();
+                  next_layer=dtLId.layer();
+                  next_lat=lat;
+                  matched_digis++;
+                }
+
 	      }
 	      
 	    }
@@ -273,33 +335,33 @@ void MuonPathAssociator::correlateMPaths(edm::Handle<DTDigiCollection> dtdigis,
 	      int new_quality=7;
 	      if(SL3metaPrimitive->quality<=2) new_quality=5;
 	      
-	      int wi1=-1;int tdc1=-1;
-	      int wi2=-1;int tdc2=-1;
-	      int wi3=-1;int tdc3=-1;
-	      int wi4=-1;int tdc4=-1;
+	      int wi1=-1;int tdc1=-1;int lat1=-1;
+	      int wi2=-1;int tdc2=-1;int lat2=-1;
+	      int wi3=-1;int tdc3=-1;int lat3=-1;
+	      int wi4=-1;int tdc4=-1;int lat4=-1;
 	      
-	      if(next_layer==1) {wi1=next_wire; tdc1=next_tdc; }
-	      if(next_layer==2) {wi2=next_wire; tdc2=next_tdc; }
-	      if(next_layer==3) {wi3=next_wire; tdc3=next_tdc; }
-	      if(next_layer==4) {wi4=next_wire; tdc4=next_tdc; }
+	      if(next_layer==1) {wi1=next_wire; tdc1=next_tdc; lat1=next_lat;}
+	      if(next_layer==2) {wi2=next_wire; tdc2=next_tdc; lat2=next_lat;}
+	      if(next_layer==3) {wi3=next_wire; tdc3=next_tdc; lat3=next_lat;}
+	      if(next_layer==4) {wi4=next_wire; tdc4=next_tdc; lat4=next_lat;}
 	      
-	      if(best_layer==1) {wi1=best_wire; tdc1=best_tdc; }
-	      if(best_layer==2) {wi2=best_wire; tdc2=best_tdc; }
-	      if(best_layer==3) {wi3=best_wire; tdc3=best_tdc; }
-	      if(best_layer==4) {wi4=best_wire; tdc4=best_tdc; } 
+	      if(best_layer==1) {wi1=best_wire; tdc1=best_tdc; lat1=best_lat;}
+	      if(best_layer==2) {wi2=best_wire; tdc2=best_tdc; lat2=best_lat;}
+	      if(best_layer==3) {wi3=best_wire; tdc3=best_tdc; lat3=best_lat;}
+	      if(best_layer==4) {wi4=best_wire; tdc4=best_tdc; lat4=best_lat;} 
 	      
 	      
 				    
 	      outMPaths.push_back(metaPrimitive({ChId.rawId(),SL3metaPrimitive->t0,SL3metaPrimitive->x,SL3metaPrimitive->tanPhi,SL3metaPrimitive->phi,SL3metaPrimitive->phiB,SL3metaPrimitive->chi2,
 		      new_quality,
-		      wi1,tdc1,
-		      wi2,tdc2,
-		      wi3,tdc3,
-		      wi4,tdc4,
-		      SL3metaPrimitive->wi1,SL3metaPrimitive->tdc1,
-		      SL3metaPrimitive->wi2,SL3metaPrimitive->tdc2,
-		      SL3metaPrimitive->wi3,SL3metaPrimitive->tdc3,
-		      SL3metaPrimitive->wi4,SL3metaPrimitive->tdc4
+		      wi1,tdc1,lat1,
+		      wi2,tdc2,lat2,
+		      wi3,tdc3,lat3,
+		      wi4,tdc4,lat4,
+		      SL3metaPrimitive->wi1,SL3metaPrimitive->tdc1,SL3metaPrimitive->lat1,
+		      SL3metaPrimitive->wi2,SL3metaPrimitive->tdc2,SL3metaPrimitive->lat2,
+		      SL3metaPrimitive->wi3,SL3metaPrimitive->tdc3,SL3metaPrimitive->lat3,
+		      SL3metaPrimitive->wi4,SL3metaPrimitive->tdc4,SL3metaPrimitive->lat4
 		      }));
 	      at_least_one_correlation=true;
 	    }


### PR DESCRIPTION
#### PR description:

Changed metaPrimitive struct to introduce lateralities in order to reconstruct positions after correlating both metaprimitives and calculate new chi2. Minor changes to the extrapolation of a metaprimitive to the other superlayer. 

#### PR validation:

<!-- Please replace this text with a description of which tests have been performed to verify the correctness of the PR, including the eventual addition of new code for testing like unit tests, test configurations, additions or updates to the runTheMatrix test workflows -->

#### if this PR is a backport please specify the original PR:

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
