### PR TITLE
Further rpc integration

### DIFF
--- a/L1Trigger/DTPhase2Trigger/doc/qualities.txt
+++ b/L1Trigger/DTPhase2Trigger/doc/qualities.txt
@@ -1,0 +1,20 @@
+Just to keep track of the fast evolving qualit definition
+#########################################################
+
+DT quality code
+---------------
+1, 2: 3-hit in a single SL
+3, 4: 4-hit in a single SL (3 means that there are other TP in this SL, 4 that it is the only one)
+5: 3-hit in a single SL + 1 or 2 hits in the other SL
+6: 3-hit in both SL
+7: 4-hit in a single SL + 1 or 2 hits in the other SL
+8: 4-hit in a SL + 3-hit in the other SL
+9: 4-hit in both SL
+
+RPC Flag (tells how RPC was used) #FIXME being implemented, not everything availabel yet
+---------------------------------
+0: RPC not used
+1: RPC used to overwrite TP timing info (both t0 and BX)
+2: RPC only segment
+3: RPC single hit
+4: RPC used to confirm the presence of the TP, but not used to recompute any of its quantities

--- a/L1Trigger/DTPhase2Trigger/interface/DTTrigPhase2Prod.h
+++ b/L1Trigger/DTPhase2Trigger/interface/DTTrigPhase2Prod.h
@@ -44,6 +44,7 @@
 #include "DataFormats/RPCRecHit/interface/RPCRecHitCollection.h"
 #include <DataFormats/MuonDetId/interface/RPCDetId.h>
 #include "Geometry/RPCGeometry/interface/RPCGeometry.h"
+#include "L1Trigger/DTPhase2Trigger/interface/RPCIntegrator.h"
 
 
 #include <fstream>
@@ -73,7 +74,6 @@ class DTTrigPhase2Prod: public edm::EDProducer{
 void endRun(edm::Run const& iRun, const edm::EventSetup& iEventSetup) override;
     
     edm::ESHandle<DTGeometry> dtGeo;
-    edm::ESHandle<RPCGeometry> rpcGeo;
 
     std::vector<std::pair<int,MuonPath>> primitives;
 
@@ -134,8 +134,9 @@ void endRun(edm::Run const& iRun, const edm::EventSetup& iEventSetup) override;
     MuonPathAssociator* mpathassociator;
 
     // RPC
+    RPCIntegrator* rpc_integrator;
     bool useRPC;
-    GlobalPoint getRPCGlobalPosition(RPCDetId rpcId, const RPCRecHit& rpcIt) const;
+
     void assignIndex(std::vector<metaPrimitive> &inMPaths);
     int assignQualityOrder(metaPrimitive mP);
 };

--- a/L1Trigger/DTPhase2Trigger/interface/RPCIntegrator.h
+++ b/L1Trigger/DTPhase2Trigger/interface/RPCIntegrator.h
@@ -1,0 +1,49 @@
+#ifndef Phase2L1Trigger_DTTrigger_RPCIntegrator_cc
+#define Phase2L1Trigger_DTTrigger_RPCIntegrator_cc
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Run.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/MuonDetId/interface/DTChamberId.h"
+#include "DataFormats/MuonDetId/interface/DTSuperLayerId.h"
+#include "DataFormats/MuonDetId/interface/DTLayerId.h"
+#include "DataFormats/MuonDetId/interface/DTWireId.h"
+#include "DataFormats/DTDigi/interface/DTDigiCollection.h"
+#include "DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTPhContainer.h"
+#include "DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTPhDigi.h"
+
+#include "DataFormats/RPCRecHit/interface/RPCRecHitCollection.h"
+#include <DataFormats/MuonDetId/interface/RPCDetId.h>
+#include "Geometry/RPCGeometry/interface/RPCGeometry.h"
+
+#include "L1Trigger/DTPhase2Trigger/interface/analtypedefs.h"
+//#include "L1Trigger/DTPhase2Trigger/interface/constants.h"
+
+
+class RPCIntegrator {
+    public:
+        RPCIntegrator(const edm::ParameterSet& pset);
+        ~RPCIntegrator();
+
+        void initialise(const edm::EventSetup& iEventSetup);
+        GlobalPoint getRPCGlobalPosition(RPCDetId rpcId, const RPCRecHit& rpcIt) const;
+        void translateRPC(edm::Handle<RPCRecHitCollection> rpcRecHits);
+        L1Phase2MuDTPhDigi* matchDTwithRPC(metaPrimitive* dt_metaprimitive);
+        void confirmDT(std::vector<metaPrimitive> & dt_metaprimitives);
+
+        std::vector<L1Phase2MuDTPhDigi> rpcRecHits_translated;
+
+    private:
+        //RPCRecHitCollection m_rpcRecHits;
+        Bool_t m_debug;
+        int m_min_quality_overwrite_t0;
+        edm::ESHandle<RPCGeometry> m_rpcGeo;
+        int m_dt_phi_granularity = 81920;
+};
+#endif

--- a/L1Trigger/DTPhase2Trigger/interface/RPCIntegrator.h
+++ b/L1Trigger/DTPhase2Trigger/interface/RPCIntegrator.h
@@ -42,7 +42,7 @@ class RPCIntegrator {
     private:
         //RPCRecHitCollection m_rpcRecHits;
         Bool_t m_debug;
-        int m_min_quality_overwrite_t0;
+        int m_max_quality_to_overwrite_t0;
         edm::ESHandle<RPCGeometry> m_rpcGeo;
         int m_dt_phi_granularity = 81920;
 };

--- a/L1Trigger/DTPhase2Trigger/interface/RPCIntegrator.h
+++ b/L1Trigger/DTPhase2Trigger/interface/RPCIntegrator.h
@@ -35,7 +35,7 @@ class RPCIntegrator {
         GlobalPoint getRPCGlobalPosition(RPCDetId rpcId, const RPCRecHit& rpcIt) const;
         void translateRPC(edm::Handle<RPCRecHitCollection> rpcRecHits);
         L1Phase2MuDTPhDigi* matchDTwithRPC(metaPrimitive* dt_metaprimitive);
-        void confirmDT(std::vector<metaPrimitive> & dt_metaprimitives);
+        void confirmDT(std::vector<metaPrimitive> & dt_metaprimitives, double shift_back);
 
         std::vector<L1Phase2MuDTPhDigi> rpcRecHits_translated;
 

--- a/L1Trigger/DTPhase2Trigger/interface/analtypedefs.h
+++ b/L1Trigger/DTPhase2Trigger/interface/analtypedefs.h
@@ -54,6 +54,7 @@ struct metaPrimitive
     int tdc8;
     int lat8;
     int index;
+    int rpcFlag = 0;
 };
 typedef struct {
     bool latQValid;

--- a/L1Trigger/DTPhase2Trigger/python/dtTriggerPhase2PrimitiveDigis_cfi.py
+++ b/L1Trigger/DTPhase2Trigger/python/dtTriggerPhase2PrimitiveDigis_cfi.py
@@ -31,7 +31,8 @@ dtTriggerPhase2PrimitiveDigis = cms.EDProducer("DTTrigPhase2Prod",
                                                dump  = cms.untracked.bool(False),
                                                #RPC
                                                rpcRecHits = cms.untracked.InputTag("rpcRecHits"),
-                                               useRPC = cms.untracked.bool(False)
+                                               useRPC = cms.untracked.bool(False),
+                                               min_quality_overwrite_t0 = cms.untracked.int32(9) # will use RPC 't0' for TP with quality < min_quality_overwrite_t0
                                                )
 
 dtTriggerPhase2PrimitiveDigis.HoughGrouping      = HoughGrouping

--- a/L1Trigger/DTPhase2Trigger/python/dtTriggerPhase2PrimitiveDigis_cfi.py
+++ b/L1Trigger/DTPhase2Trigger/python/dtTriggerPhase2PrimitiveDigis_cfi.py
@@ -32,7 +32,7 @@ dtTriggerPhase2PrimitiveDigis = cms.EDProducer("DTTrigPhase2Prod",
                                                #RPC
                                                rpcRecHits = cms.untracked.InputTag("rpcRecHits"),
                                                useRPC = cms.untracked.bool(False),
-                                               min_quality_overwrite_t0 = cms.untracked.int32(9) # will use RPC 't0' for TP with quality < min_quality_overwrite_t0
+                                               max_quality_to_overwrite_t0 = cms.untracked.int32(9) # will use RPC  to set 't0' for TP with quality < max_quality_to_overwrite_t0
                                                )
 
 dtTriggerPhase2PrimitiveDigis.HoughGrouping      = HoughGrouping

--- a/L1Trigger/DTPhase2Trigger/src/DTTrigPhase2Prod.cc
+++ b/L1Trigger/DTPhase2Trigger/src/DTTrigPhase2Prod.cc
@@ -348,13 +348,25 @@ void DTTrigPhase2Prod::produce(Event & iEvent, const EventSetup& iEventSetup){
 	  cout<<endl;
       } 
     }
+
+    double shift_back=0;
+
+    //if (iEvent.eventAuxiliary().run() == 1) //FIX MC
+    if(scenario == 0)//scope for MC
+        shift_back = 400;
+
+    if(scenario == 1)//scope for data
+        shift_back=0;
+
+    if(scenario == 2)//scope for slice test
+        shift_back=0;
     
     // RPC integration
     if(useRPC) {
         if (debug) std::cout << "Start integrating RPC" << std::endl;
         rpc_integrator->initialise(iEventSetup);
         rpc_integrator->translateRPC(rpcRecHits);
-        rpc_integrator->confirmDT(correlatedMetaPrimitives);
+        rpc_integrator->confirmDT(correlatedMetaPrimitives, shift_back);
     }
 
     /// STORING RESULTs 
@@ -378,38 +390,25 @@ void DTTrigPhase2Prod::produce(Event & iEvent, const EventSetup& iEventSetup){
 	  if(inner((*metaPrimitiveIt))) sl=1;
 	  else sl=3;
       }
-
-      double shift_back=0;
-      
-      //if (iEvent.eventAuxiliary().run() == 1) //FIX MC                                                                                                 
-      if(scenario == 0)//scope for MC
-	  shift_back = 400;
-
-      if(scenario == 1)//scope for data
-	  shift_back=0;
-      
-      if(scenario == 2)//scope for slice test
-	  shift_back=0;
-      
 	  
       if(p2_df==2){
-	  if(debug)std::cout<<"pushing back phase-2 dataformat carlo-federica dataformat"<<std::endl;
-	  outP2Ph.push_back(L1Phase2MuDTPhDigi((int)round((*metaPrimitiveIt).t0/25.)-shift_back,   // ubx (m_bx) //bx en la orbita
-					       chId.wheel(),   // uwh (m_wheel)     // FIXME: It is not clear who provides this?
-					       sectorTP,   // usc (m_sector)    // FIXME: It is not clear who provides this?
-					       chId.station(),   // ust (m_station)
-					       sl,   // ust (m_station)
-					       (int)round((*metaPrimitiveIt).phi*65536./0.8), // uphi (_phiAngle)
-					       (int)round((*metaPrimitiveIt).phiB*2048./1.4), // uphib (m_phiBending)
-					       (*metaPrimitiveIt).quality,  // uqua (m_qualityCode)
-					       (*metaPrimitiveIt).index,  // uind (m_segmentIndex)
-					       (int)round((*metaPrimitiveIt).t0)-shift_back*25,  // ut0 (m_t0Segment)
-					       (int)round((*metaPrimitiveIt).chi2*1000000),  // uchi2 (m_chi2Segment)
-					       (*metaPrimitiveIt).rpcFlag    // urpc (m_rpcFlag)
-					       ));
-	
+          if(debug)std::cout<<"pushing back phase-2 dataformat carlo-federica dataformat"<<std::endl;
+          outP2Ph.push_back(L1Phase2MuDTPhDigi((int)round((*metaPrimitiveIt).t0/25.)-shift_back,   // ubx (m_bx) //bx en la orbita
+                               chId.wheel(),   // uwh (m_wheel)     // FIXME: It is not clear who provides this?
+                               sectorTP,   // usc (m_sector)    // FIXME: It is not clear who provides this?
+                               chId.station(),   // ust (m_station)
+                               sl,   // ust (m_station)
+                               (int)round((*metaPrimitiveIt).phi*65536./0.8), // uphi (_phiAngle)
+                               (int)round((*metaPrimitiveIt).phiB*2048./1.4), // uphib (m_phiBending)
+                               (*metaPrimitiveIt).quality,  // uqua (m_qualityCode)
+                               (*metaPrimitiveIt).index,  // uind (m_segmentIndex)
+                               (int)round((*metaPrimitiveIt).t0)-shift_back*25,  // ut0 (m_t0Segment)
+                               (int)round((*metaPrimitiveIt).chi2*1000000),  // uchi2 (m_chi2Segment)
+                               (*metaPrimitiveIt).rpcFlag    // urpc (m_rpcFlag)
+                               ));
       }
     }
+
     // Storing RPC hits that were not used elsewhere
     if(p2_df == 2 && useRPC) {
         for (auto rpc_dt_digi = rpc_integrator->rpcRecHits_translated.begin(); rpc_dt_digi != rpc_integrator->rpcRecHits_translated.end(); rpc_dt_digi++) {

--- a/L1Trigger/DTPhase2Trigger/src/RPCIntegrator.cc
+++ b/L1Trigger/DTPhase2Trigger/src/RPCIntegrator.cc
@@ -101,13 +101,14 @@ L1Phase2MuDTPhDigi* RPCIntegrator::matchDTwithRPC(metaPrimitive* dt_metaprimitiv
     return bestMatch_rpcRecHit;
 }
 
-void RPCIntegrator::confirmDT(std::vector<metaPrimitive> & dt_metaprimitives) {
+void RPCIntegrator::confirmDT(std::vector<metaPrimitive> & dt_metaprimitives, double shift_back) {
     for (auto dt_metaprimitive = dt_metaprimitives.begin(); dt_metaprimitive != dt_metaprimitives.end(); dt_metaprimitive++) {
         L1Phase2MuDTPhDigi* bestMatch_rpcRecHit = matchDTwithRPC(&*dt_metaprimitive);
         if (bestMatch_rpcRecHit) {
             (*dt_metaprimitive).rpcFlag = 4;
             if ((*dt_metaprimitive).quality < m_min_quality_overwrite_t0){
-                (*dt_metaprimitive).t0 = bestMatch_rpcRecHit->t0(); // Overwriting t0 will propagates to BX since it is defined by round((*metaPrimitiveIt).t0/25.)-shift_back
+                (*dt_metaprimitive).t0 = bestMatch_rpcRecHit->t0() + 25 * shift_back; // Overwriting t0 will propagates to BX since it is defined by round((*metaPrimitiveIt).t0/25.)-shift_back
+                                                                                      // but we need to add this shift back since all RPC chamber time is centered at 0 for prompt muon
                 (*dt_metaprimitive).rpcFlag = 1;
             }
         }

--- a/L1Trigger/DTPhase2Trigger/src/RPCIntegrator.cc
+++ b/L1Trigger/DTPhase2Trigger/src/RPCIntegrator.cc
@@ -8,7 +8,7 @@
 RPCIntegrator::RPCIntegrator(const edm::ParameterSet& pset){
     m_debug = pset.getUntrackedParameter<Bool_t>("debug");
     if (m_debug) std::cout <<"RPCIntegrator constructor" << std::endl;
-    m_min_quality_overwrite_t0 = pset.getUntrackedParameter<int>("min_quality_overwrite_t0");
+    m_max_quality_to_overwrite_t0 = pset.getUntrackedParameter<int>("max_quality_to_overwrite_t0");
 }
 
 RPCIntegrator::~RPCIntegrator() {
@@ -106,7 +106,7 @@ void RPCIntegrator::confirmDT(std::vector<metaPrimitive> & dt_metaprimitives, do
         L1Phase2MuDTPhDigi* bestMatch_rpcRecHit = matchDTwithRPC(&*dt_metaprimitive);
         if (bestMatch_rpcRecHit) {
             (*dt_metaprimitive).rpcFlag = 4;
-            if ((*dt_metaprimitive).quality < m_min_quality_overwrite_t0){
+            if ((*dt_metaprimitive).quality < m_max_quality_to_overwrite_t0){
                 (*dt_metaprimitive).t0 = bestMatch_rpcRecHit->t0() + 25 * shift_back; // Overwriting t0 will propagates to BX since it is defined by round((*metaPrimitiveIt).t0/25.)-shift_back
                                                                                       // but we need to add this shift back since all RPC chamber time is centered at 0 for prompt muon
                 (*dt_metaprimitive).rpcFlag = 1;
@@ -114,14 +114,3 @@ void RPCIntegrator::confirmDT(std::vector<metaPrimitive> & dt_metaprimitives, do
         }
     }
 }
-
-
-
-
-
-
-
-
-
-
-

--- a/L1Trigger/DTPhase2Trigger/src/RPCIntegrator.cc
+++ b/L1Trigger/DTPhase2Trigger/src/RPCIntegrator.cc
@@ -1,0 +1,126 @@
+#include "FWCore/Utilities/interface/ESGetToken.h"
+#include "FWCore/Utilities/interface/ESInputTag.h"
+
+#include "L1Trigger/DTPhase2Trigger/interface/RPCIntegrator.h"
+
+#include <Geometry/Records/interface/MuonGeometryRecord.h>
+
+RPCIntegrator::RPCIntegrator(const edm::ParameterSet& pset){
+    m_debug = pset.getUntrackedParameter<Bool_t>("debug");
+    if (m_debug) std::cout <<"RPCIntegrator constructor" << std::endl;
+    m_min_quality_overwrite_t0 = pset.getUntrackedParameter<int>("min_quality_overwrite_t0");
+}
+
+RPCIntegrator::~RPCIntegrator() {
+    if (m_debug) std::cout <<"RPCIntegrator destructor" << std::endl;
+}
+
+void RPCIntegrator::initialise(const edm::EventSetup& iEventSetup) {
+    if (m_debug) std::cout << "RPCIntegrator initialisation" << std::endl;
+    
+    if (m_debug) std::cout << "Getting RPC geometry" << std::endl;
+    iEventSetup.get<MuonGeometryRecord>().get(m_rpcGeo);
+}
+
+GlobalPoint RPCIntegrator::getRPCGlobalPosition(RPCDetId rpcId, const RPCRecHit& rpcIt) const{
+
+  RPCDetId rpcid = RPCDetId(rpcId);
+  const LocalPoint& rpc_lp = rpcIt.localPosition();
+  const GlobalPoint& rpc_gp = m_rpcGeo->idToDet(rpcid)->surface().toGlobal(rpc_lp);
+
+  return rpc_gp;
+
+}
+
+void RPCIntegrator::translateRPC(edm::Handle<RPCRecHitCollection> rpcRecHits) {
+    rpcRecHits_translated.clear();
+    for (RPCRecHitCollection::const_iterator rpcIt = rpcRecHits->begin(); rpcIt != rpcRecHits->end(); rpcIt++) {
+        // Retrieve RPC info and translate it to DT convention if needed
+        int rpc_bx = rpcIt->BunchX();
+        int rpc_time = int(rpcIt->time());
+        RPCDetId rpcDetId = (RPCDetId)(*rpcIt).rpcId();
+        if (m_debug) std::cout << "Getting RPC info from : " << rpcDetId << std::endl;
+        int rpc_region = rpcDetId.region();
+        if(rpc_region != 0 ) continue; // Region = 0 Barrel
+        int rpc_wheel = rpcDetId.ring(); // In barrel, wheel is accessed via ring() method ([-2,+2])
+        int rpc_dt_sector = rpcDetId.sector()-1; // DT sector:[0,11] while RPC sector:[1,12]
+        int rpc_station = rpcDetId.station();
+        int rpc_layer = rpcDetId.layer();
+
+        if (m_debug) std::cout << "Getting RPC global point and translating to DT local coordinates" << std::endl;
+        GlobalPoint rpc_gp = getRPCGlobalPosition(rpcDetId, *rpcIt);
+        double rpc_global_phi = rpc_gp.phi();
+        int rpc_localDT_phi = std::numeric_limits<int>::min();
+        // Adaptation of https://github.com/cms-sw/cmssw/blob/master/L1Trigger/L1TTwinMux/src/RPCtoDTTranslator.cc#L349
+        if (rpcDetId.sector() == 1) rpc_localDT_phi = int(rpc_global_phi * m_dt_phi_granularity);
+        else {
+            if (rpc_global_phi >= 0) rpc_localDT_phi = int((rpc_global_phi - (rpcDetId.sector() - 1) * Geom::pi() / 6.) * m_dt_phi_granularity);
+            else rpc_localDT_phi = int((rpc_global_phi + (13 - rpcDetId.sector()) * Geom::pi() / 6.) * m_dt_phi_granularity);
+        }
+        int rpc_phiB = -100000; // single hit has no phiB, DT phiB ranges approx from -1500 to 1500
+        int rpc_quality = -1; // to be decided
+        int rpc_index = 0;
+        int rpc_flag = 3; // only single hit for now
+        if (m_debug) std::cout << "Creating DT TP out of RPC recHits" << std::endl;
+        rpcRecHits_translated.push_back(L1Phase2MuDTPhDigi(rpc_bx,
+                        rpc_wheel,
+                        rpc_dt_sector,
+                        rpc_station,
+                        rpc_layer, //this would be the layer in the new dataformat
+                        rpc_localDT_phi,
+                        rpc_phiB,
+                        rpc_quality,
+                        rpc_index,
+                        rpc_time,
+                        -1, // signle hit --> no chi2
+                        rpc_flag
+                        ));
+    }
+}
+
+L1Phase2MuDTPhDigi* RPCIntegrator::matchDTwithRPC(metaPrimitive* dt_metaprimitive) {
+    DTChamberId dt_chId = DTChamberId(dt_metaprimitive->rawId);
+    int sectorTP = dt_chId.sector();
+    if (sectorTP == 13) sectorTP = 4;
+    if (sectorTP == 14) sectorTP = 10;
+    sectorTP = sectorTP - 1;
+    L1Phase2MuDTPhDigi* bestMatch_rpcRecHit = NULL;
+    float min_dPhi = std::numeric_limits<float>::max();
+    for (auto rpcRecHit_translated = rpcRecHits_translated.begin(); rpcRecHit_translated != rpcRecHits_translated.end(); rpcRecHit_translated++) {
+        if (rpcRecHit_translated->whNum() == dt_chId.wheel() && rpcRecHit_translated->stNum() == dt_chId.station() && rpcRecHit_translated->scNum() == sectorTP) {
+            //if (min_dPhi != std::numeric_limits<float>::max()){
+            //    std::cout << "More than one match for DT/RPC" << dt_chId << std::endl;
+            //}
+            // Select the RPC hit closest in phi to the DT meta primitive
+            if (std::abs(rpcRecHit_translated->phi() - dt_metaprimitive->phi) < min_dPhi){
+                min_dPhi = std::abs(rpcRecHit_translated->phi() - dt_metaprimitive->phi);
+                bestMatch_rpcRecHit = &*rpcRecHit_translated;
+            }
+        }
+    }
+    return bestMatch_rpcRecHit;
+}
+
+void RPCIntegrator::confirmDT(std::vector<metaPrimitive> & dt_metaprimitives) {
+    for (auto dt_metaprimitive = dt_metaprimitives.begin(); dt_metaprimitive != dt_metaprimitives.end(); dt_metaprimitive++) {
+        L1Phase2MuDTPhDigi* bestMatch_rpcRecHit = matchDTwithRPC(&*dt_metaprimitive);
+        if (bestMatch_rpcRecHit) {
+            (*dt_metaprimitive).rpcFlag = 4;
+            if ((*dt_metaprimitive).quality < m_min_quality_overwrite_t0){
+                (*dt_metaprimitive).t0 = bestMatch_rpcRecHit->t0(); // Overwriting t0 will propagates to BX since it is defined by round((*metaPrimitiveIt).t0/25.)-shift_back
+                (*dt_metaprimitive).rpcFlag = 1;
+            }
+        }
+    }
+}
+
+
+
+
+
+
+
+
+
+
+

--- a/L1Trigger/DTPhase2Trigger/test/primitivesPhase2Prod_over_dTDigis_and_4Dsegments_cfg_withRPC.py
+++ b/L1Trigger/DTPhase2Trigger/test/primitivesPhase2Prod_over_dTDigis_and_4Dsegments_cfg_withRPC.py
@@ -36,7 +36,7 @@ process.rpcRecHits.rpcDigiLabel = cms.InputTag('simMuonRPCDigis')
 process.load('Configuration.Geometry.GeometryExtended2023D38Reco_cff')
 process.load('Configuration.Geometry.GeometryExtended2023D38_cff')
 process.dtTriggerPhase2PrimitiveDigis.useRPC = True
-process.dtTriggerPhase2PrimitiveDigis.min_quality_overwrite_t0 = 10
+process.dtTriggerPhase2PrimitiveDigis.max_quality_to_overwrite_t0 = 9 # strict inequality
 process.dtTriggerPhase2PrimitiveDigis.scenario = 0 # 0 for mc, 1 for data, 2 for slice test
 
 process.source = cms.Source("PoolSource",fileNames = cms.untracked.vstring(

--- a/L1Trigger/DTPhase2Trigger/test/primitivesPhase2Prod_over_dTDigis_and_4Dsegments_cfg_withRPC.py
+++ b/L1Trigger/DTPhase2Trigger/test/primitivesPhase2Prod_over_dTDigis_and_4Dsegments_cfg_withRPC.py
@@ -16,6 +16,7 @@ process.GlobalTag.globaltag = "106X_upgrade2018_realistic_v4"
 #Calibrate Digis
 process.load("Phase2L1Trigger.CalibratedDigis.CalibratedDigis_cfi")
 process.CalibratedDigis.dtDigiTag = "simMuonDTDigis"
+process.CalibratedDigis.scenario = 0 # 0 for mc, 1 for data, 2 for slice test
 #process.CalibratedDigis.flat_calib = 325 #turn to 0 to use the DB  , 325 for JM and Jorge benchmark
 
 #DTTriggerPhase2
@@ -35,6 +36,8 @@ process.rpcRecHits.rpcDigiLabel = cms.InputTag('simMuonRPCDigis')
 process.load('Configuration.Geometry.GeometryExtended2023D38Reco_cff')
 process.load('Configuration.Geometry.GeometryExtended2023D38_cff')
 process.dtTriggerPhase2PrimitiveDigis.useRPC = True
+process.dtTriggerPhase2PrimitiveDigis.min_quality_overwrite_t0 = 10
+process.dtTriggerPhase2PrimitiveDigis.scenario = 0 # 0 for mc, 1 for data, 2 for slice test
 
 process.source = cms.Source("PoolSource",fileNames = cms.untracked.vstring(
         #'file:/eos/user/c/carrillo/digis_segments_Run2016BSingleMuonRAW-RECO.root'
@@ -43,19 +46,14 @@ process.source = cms.Source("PoolSource",fileNames = cms.untracked.vstring(
         )
                             )
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(1000)
+    input = cms.untracked.int32(5000)
 )
 
 process.out = cms.OutputModule("PoolOutputModule",
                                outputCommands = cms.untracked.vstring('keep *'),
-                               fileName = cms.untracked.string('DTTriggerPhase2Primitives1000_withRPC.root')
+                               fileName = cms.untracked.string('DTTriggerPhase2Primitives5000_withRPC.root')
 )
 
 process.p = cms.Path(process.rpcRecHits*process.CalibratedDigis*process.dtTriggerPhase2PrimitiveDigis)
 process.this_is_the_end = cms.EndPath(process.out)
-
-
-
-
-
 

--- a/L1Trigger/DTPhase2Trigger/test/primitivesPhase2Prod_over_dTDigis_and_4Dsegments_cfg_withRPC.py
+++ b/L1Trigger/DTPhase2Trigger/test/primitivesPhase2Prod_over_dTDigis_and_4Dsegments_cfg_withRPC.py
@@ -9,10 +9,9 @@ process.DTGeometryESModule.applyAlignment = False
 process.load("L1Trigger.DTPhase2Trigger.dtTriggerPhase2PrimitiveDigis_cfi")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 process.load("Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff")
-#process.GlobalTag.globaltag = "90X_dataRun2_Express_v2"
-#process.GlobalTag.globaltag = "80X_dataRun2_2016SeptRepro_v7"
-from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
+process.GlobalTag.globaltag = "106X_upgrade2018_realistic_v4"
+#from Configuration.AlCa.GlobalTag import GlobalTag
+#process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:phase2_realistic', '')
 
 #Calibrate Digis
 process.load("Phase2L1Trigger.CalibratedDigis.CalibratedDigis_cfi")
@@ -40,15 +39,16 @@ process.dtTriggerPhase2PrimitiveDigis.useRPC = True
 process.source = cms.Source("PoolSource",fileNames = cms.untracked.vstring(
         #'file:/eos/user/c/carrillo/digis_segments_Run2016BSingleMuonRAW-RECO.root'
         'file:/eos/cms/store/group/dpg_dt/comm_dt/TriggerSimulation/SamplesReco/SingleMu_FlatPt-2to100/Version_10_5_0/SimRECO_1.root'
+        #'file:/eos/cms/store/group/dpg_rpc/comm_rpc/UpgradePhaseII/RPC_PLUS_DT/SingleMu_FlatPt-2to100_10_5_0_MaryCruz_WithRPCRecHits/SimRECO_1.root'
         )
                             )
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(100)
+    input = cms.untracked.int32(1000)
 )
 
 process.out = cms.OutputModule("PoolOutputModule",
                                outputCommands = cms.untracked.vstring('keep *'),
-                               fileName = cms.untracked.string('DTTriggerPhase2Primitives100_withRPC.root')
+                               fileName = cms.untracked.string('DTTriggerPhase2Primitives1000_withRPC.root')
 )
 
 process.p = cms.Path(process.rpcRecHits*process.CalibratedDigis*process.dtTriggerPhase2PrimitiveDigis)

--- a/L1Trigger/DTPhase2Trigger/test/primitivesPhase2Prod_over_mc_cfg.py
+++ b/L1Trigger/DTPhase2Trigger/test/primitivesPhase2Prod_over_mc_cfg.py
@@ -17,6 +17,7 @@ process.GlobalTag.globaltag = "100X_upgrade2018_realistic_v10"
 process.load("Phase2L1Trigger.CalibratedDigis.CalibratedDigis_cfi")
 #process.CalibratedDigis.flat_calib = 325 #turn to 0 to use the DB  , 325 for JM and Jorge benchmark
 process.CalibratedDigis.dtDigiTag = "simMuonDTDigis" #turn to 0 to use the DB  , 325 for JM and Jorge benchmark
+process.CalibratedDigis.scenario = 0 # 0 for mc, 1 for data, 2 for slice test
 
 #DTTriggerPhase2
 process.load("L1Trigger.DTPhase2Trigger.dtTriggerPhase2PrimitiveDigis_cfi")

--- a/L1Trigger/DTPhase2Trigger/test/primitivesPhase2Prod_over_mc_cfg.py
+++ b/L1Trigger/DTPhase2Trigger/test/primitivesPhase2Prod_over_mc_cfg.py
@@ -28,6 +28,7 @@ process.load("L1Trigger.DTPhase2Trigger.dtTriggerPhase2PrimitiveDigis_cfi")
 #process.dtTriggerPhase2PrimitiveDigis.pinta = True
 #process.dtTriggerPhase2PrimitiveDigis.min_phinhits_match_segment = 4
 #process.dtTriggerPhase2PrimitiveDigis.debug = True
+process.dtTriggerPhase2PrimitiveDigis.scenario = 0
 
 process.source = cms.Source("PoolSource",fileNames = cms.untracked.vstring(
         'file:/eos/cms/store/group/dpg_dt/comm_dt/TriggerSimulation/SamplesReco/SingleMu_FlatPt-2to100/Version_10_5_0/SimRECO_1.root',
@@ -51,7 +52,7 @@ process.maxEvents = cms.untracked.PSet(
 
 process.out = cms.OutputModule("PoolOutputModule",
                                outputCommands = cms.untracked.vstring('keep *'),
-                               fileName = cms.untracked.string('/tmp/carrillo/mc/DTTriggerPhase2Primitives.root')
+                               fileName = cms.untracked.string('DTTriggerPhase2Primitives_testsmc.root')
 )
 
 process.p = cms.Path(process.CalibratedDigis*process.dtTriggerPhase2PrimitiveDigis)


### PR DESCRIPTION
 - Factorize everything related to RPC outside of `DTTrigPhase2Prod.cc` by creating the new `RPCIntegrator.cc` class
 - Add functionality to match DT metaprimitives with RPC clusters (matching procedure will be improved later)
 - Add possibility to set `t0` by using RPC time for some DT TP quality (parametrized by `max_quality_to_overwrite_t0`)
 - `useRPC` still set to `False` by default (default behavior of the DT TPG still left untouched), if it is set to `True`, `t0` will be taken from RPC for TP with quality < 9
 - Validation: [link](https://indico.cern.ch/event/786942/contributions/3505923/attachments/1882702/3102550/20190718_RPC_DT_P2TP.pdf) 