### PR TITLE
RPC only segment and more

### DIFF
--- a/L1Trigger/DTPhase2Trigger/doc/qualities.txt
+++ b/L1Trigger/DTPhase2Trigger/doc/qualities.txt
@@ -13,7 +13,7 @@ DT quality code
 
 RPC Flag (tells how RPC was used) #FIXME being implemented, not everything availabel yet
 ---------------------------------
-0: RPC not used
+0: RPC not used or segment that could not be mathced to any RPC cluster
 1: RPC used to overwrite TP timing info (both t0 and BX)
 2: RPC only segment
 3: RPC single hit

--- a/L1Trigger/DTPhase2Trigger/doc/qualities.txt
+++ b/L1Trigger/DTPhase2Trigger/doc/qualities.txt
@@ -13,8 +13,9 @@ DT quality code
 
 RPC Flag (tells how RPC was used) #FIXME being implemented, not everything availabel yet
 ---------------------------------
-0: RPC not used or segment that could not be mathced to any RPC cluster
+0: segment that could not be mathced to any RPC cluster (or 'useRPC' option is set to false)
 1: RPC used to overwrite TP timing info (both t0 and BX)
 2: RPC only segment
-3: RPC single hit
+3: RPC single hit not associated to any DT segment
 4: RPC used to confirm the presence of the TP, but not used to recompute any of its quantities
+5: RPC single hit associated with a DT segment (only kept if 'storeAllRPCHits' is set to True, which not the default)

--- a/L1Trigger/DTPhase2Trigger/interface/RPCIntegrator.h
+++ b/L1Trigger/DTPhase2Trigger/interface/RPCIntegrator.h
@@ -32,10 +32,16 @@ class RPCIntegrator {
         ~RPCIntegrator();
 
         void initialise(const edm::EventSetup& iEventSetup);
+        void finish();
         GlobalPoint getRPCGlobalPosition(RPCDetId rpcId, const RPCRecHit& rpcIt) const;
         void translateRPC(edm::Handle<RPCRecHitCollection> rpcRecHits);
         L1Phase2MuDTPhDigi* matchDTwithRPC(metaPrimitive* dt_metaprimitive, double shift_back);
         void confirmDT(std::vector<metaPrimitive> & dt_metaprimitives, double shift_back);
+        void makeRPConlySegments();
+        int getPhiBending(L1Phase2MuDTPhDigi* rpc_hit_1, L1Phase2MuDTPhDigi* rpc_hit_2);
+        int getLocalX(int phi, int layer, int station);
+        bool hasPosRF_rpc(int wh, int sec);
+        void removeRPCHitsMatched();
 
         std::vector<L1Phase2MuDTPhDigi> rpcRecHits_translated;
 
@@ -47,5 +53,8 @@ class RPCIntegrator {
         bool m_storeAllRPCHits;
         edm::ESHandle<RPCGeometry> m_rpcGeo;
         int m_dt_phi_granularity = 81920;
+        //R[stat][layer] - radius of rpc station/layer from center of CMS
+        double R[2][2] = {{410.0, 444.8}, {492.7, 527.3}};
+        //float m_radius_rb1_layer1 = 410.0, m_radius_rb1_layer2 = 444.8, m_radius_rb2_layer1 = 492.7, m_radius_rb2_layer2 = 527.3;
 };
 #endif

--- a/L1Trigger/DTPhase2Trigger/interface/RPCIntegrator.h
+++ b/L1Trigger/DTPhase2Trigger/interface/RPCIntegrator.h
@@ -22,39 +22,76 @@
 #include <DataFormats/MuonDetId/interface/RPCDetId.h>
 #include "Geometry/RPCGeometry/interface/RPCGeometry.h"
 
-#include "L1Trigger/DTPhase2Trigger/interface/analtypedefs.h"
-//#include "L1Trigger/DTPhase2Trigger/interface/constants.h"
+//DT geometry
+#include <Geometry/Records/interface/MuonGeometryRecord.h>
+#include <Geometry/DTGeometry/interface/DTGeometry.h>
+#include "Geometry/DTGeometry/interface/DTLayer.h"
+#include "DataFormats/MuonDetId/interface/DTWireId.h"
+#include "DQM/DTMonitorModule/interface/DTTrigGeomUtils.h"
 
+#include "L1Trigger/DTPhase2Trigger/interface/analtypedefs.h"
+
+struct rpc_metaprimitive {
+    RPCDetId rpc_id;
+    const RPCRecHit* rpc_cluster;
+    GlobalPoint global_position;
+    int rpcFlag;
+    int rpc_bx;
+    double rpc_t0;
+    rpc_metaprimitive(RPCDetId rpc_id_construct, const RPCRecHit* rpc_cluster_construct, GlobalPoint global_position_construct, int rpcFlag_construct, int rpc_bx_construct, double rpc_t0_construct) : rpc_id(rpc_id_construct), rpc_cluster(rpc_cluster_construct), global_position(global_position_construct), rpcFlag(rpcFlag_construct), rpc_bx(rpc_bx_construct), rpc_t0(rpc_t0_construct) { }
+};
+
+// change to this one if DT bx centered at zero again
+//struct rpc_metaprimitive {
+//    RPCDetId rpc_id;
+//    const RPCRecHit* rpc_cluster;
+//    GlobalPoint global_position;
+//    int rpcFlag;
+//    rpc_metaprimitive(RPCDetId rpc_id_construct, const RPCRecHit* rpc_cluster_construct, GlobalPoint global_position_construct, int rpcFlag_construct) : rpc_id(rpc_id_construct), rpc_cluster(rpc_cluster_construct), global_position(global_position_construct), rpcFlag(rpcFlag_construct) { }
+//};
 
 class RPCIntegrator {
     public:
         RPCIntegrator(const edm::ParameterSet& pset);
         ~RPCIntegrator();
 
-        void initialise(const edm::EventSetup& iEventSetup);
+        void initialise(const edm::EventSetup& iEventSetup, double shift_back_fromDT);
         void finish();
+
+        void prepareMetaPrimitives(edm::Handle<RPCRecHitCollection> rpcRecHits);
+        void matchWithDTAndUseRPCTime(std::vector<metaPrimitive> & dt_metaprimitives);
+        void makeRPCOnlySegments();
+        void storeRPCSingleHits();
+        void removeRPCHitsUsed();
+
+        rpc_metaprimitive* matchDTwithRPC(metaPrimitive* dt_metaprimitive);
+        L1Phase2MuDTPhDigi createL1Phase2MuDTPhDigi(RPCDetId rpcDetId, int rpc_bx, double rpc_time, double rpc_global_phi, double phiB, int rpc_flag);
+
+        double getPhiBending(rpc_metaprimitive* rpc_hit_1, rpc_metaprimitive* rpc_hit_2);
+        int getPhiInDTTPFormat(double rpc_global_phi, int rpcSector);
         GlobalPoint getRPCGlobalPosition(RPCDetId rpcId, const RPCRecHit& rpcIt) const;
-        void translateRPC(edm::Handle<RPCRecHitCollection> rpcRecHits);
-        L1Phase2MuDTPhDigi* matchDTwithRPC(metaPrimitive* dt_metaprimitive, double shift_back);
-        void confirmDT(std::vector<metaPrimitive> & dt_metaprimitives, double shift_back);
-        void makeRPConlySegments();
-        int getPhiBending(L1Phase2MuDTPhDigi* rpc_hit_1, L1Phase2MuDTPhDigi* rpc_hit_2);
-        int getLocalX(int phi, int layer, int station);
+        double getPhi_DT_MP_conv(double rpc_global_phi, int rpcSector);
         bool hasPosRF_rpc(int wh, int sec);
-        void removeRPCHitsMatched();
 
         std::vector<L1Phase2MuDTPhDigi> rpcRecHits_translated;
+        std::vector<rpc_metaprimitive> rpc_metaprimitives;
 
     private:
         //RPCRecHitCollection m_rpcRecHits;
         Bool_t m_debug;
         int m_max_quality_to_overwrite_t0;
         int m_bx_window;
+        double m_phi_window;
         bool m_storeAllRPCHits;
         edm::ESHandle<RPCGeometry> m_rpcGeo;
-        int m_dt_phi_granularity = 81920;
+        edm::ESHandle<DTGeometry> m_dtGeo;
+        double m_dt_phi_granularity = 65536. / 0.8; // 65536 different values per 0.8 radian
+        double m_dt_phiB_granularity = 2048. / 1.4; // 2048. different values per 1.4 radian
+        // Constant geometry values
         //R[stat][layer] - radius of rpc station/layer from center of CMS
         double R[2][2] = {{410.0, 444.8}, {492.7, 527.3}};
+        double distance_between_two_rpc_layers = 35; // in cm
+        double shift_back;
         //float m_radius_rb1_layer1 = 410.0, m_radius_rb1_layer2 = 444.8, m_radius_rb2_layer1 = 492.7, m_radius_rb2_layer2 = 527.3;
 };
 #endif

--- a/L1Trigger/DTPhase2Trigger/interface/RPCIntegrator.h
+++ b/L1Trigger/DTPhase2Trigger/interface/RPCIntegrator.h
@@ -43,6 +43,7 @@ class RPCIntegrator {
         //RPCRecHitCollection m_rpcRecHits;
         Bool_t m_debug;
         int m_max_quality_to_overwrite_t0;
+        bool m_storeAllRPCHits;
         edm::ESHandle<RPCGeometry> m_rpcGeo;
         int m_dt_phi_granularity = 81920;
 };

--- a/L1Trigger/DTPhase2Trigger/interface/RPCIntegrator.h
+++ b/L1Trigger/DTPhase2Trigger/interface/RPCIntegrator.h
@@ -34,7 +34,7 @@ class RPCIntegrator {
         void initialise(const edm::EventSetup& iEventSetup);
         GlobalPoint getRPCGlobalPosition(RPCDetId rpcId, const RPCRecHit& rpcIt) const;
         void translateRPC(edm::Handle<RPCRecHitCollection> rpcRecHits);
-        L1Phase2MuDTPhDigi* matchDTwithRPC(metaPrimitive* dt_metaprimitive);
+        L1Phase2MuDTPhDigi* matchDTwithRPC(metaPrimitive* dt_metaprimitive, double shift_back);
         void confirmDT(std::vector<metaPrimitive> & dt_metaprimitives, double shift_back);
 
         std::vector<L1Phase2MuDTPhDigi> rpcRecHits_translated;
@@ -43,6 +43,7 @@ class RPCIntegrator {
         //RPCRecHitCollection m_rpcRecHits;
         Bool_t m_debug;
         int m_max_quality_to_overwrite_t0;
+        int m_bx_window;
         bool m_storeAllRPCHits;
         edm::ESHandle<RPCGeometry> m_rpcGeo;
         int m_dt_phi_granularity = 81920;

--- a/L1Trigger/DTPhase2Trigger/python/dtTriggerPhase2PrimitiveDigis_cfi.py
+++ b/L1Trigger/DTPhase2Trigger/python/dtTriggerPhase2PrimitiveDigis_cfi.py
@@ -32,7 +32,8 @@ dtTriggerPhase2PrimitiveDigis = cms.EDProducer("DTTrigPhase2Prod",
                                                #RPC
                                                rpcRecHits = cms.untracked.InputTag("rpcRecHits"),
                                                useRPC = cms.untracked.bool(False),
-                                               max_quality_to_overwrite_t0 = cms.untracked.int32(9), # will use RPC  to set 't0' for TP with quality < max_quality_to_overwrite_t0
+                                               bx_window = cms.untracked.int32(1), # will look for RPC cluster within a bunch crossing window of 'dt.BX +- bx_window' 
+                                               max_quality_to_overwrite_t0 = cms.untracked.int32(9), # will use RPC  to set 't0' for TP with quality < 'max_quality_to_overwrite_t0'
                                                storeAllRPCHits = cms.untracked.bool(False)
                                                )
 

--- a/L1Trigger/DTPhase2Trigger/python/dtTriggerPhase2PrimitiveDigis_cfi.py
+++ b/L1Trigger/DTPhase2Trigger/python/dtTriggerPhase2PrimitiveDigis_cfi.py
@@ -33,6 +33,7 @@ dtTriggerPhase2PrimitiveDigis = cms.EDProducer("DTTrigPhase2Prod",
                                                rpcRecHits = cms.untracked.InputTag("rpcRecHits"),
                                                useRPC = cms.untracked.bool(False),
                                                bx_window = cms.untracked.int32(1), # will look for RPC cluster within a bunch crossing window of 'dt.BX +- bx_window' 
+                                               phi_window = cms.untracked.double(50.), # will look for RPC cluster within a phi window of +- phi_window in arbitrary coordinates (plot the value we cut on in RPCIntergator to fine tune it)
                                                max_quality_to_overwrite_t0 = cms.untracked.int32(9), # will use RPC  to set 't0' for TP with quality < 'max_quality_to_overwrite_t0'
                                                storeAllRPCHits = cms.untracked.bool(False)
                                                )

--- a/L1Trigger/DTPhase2Trigger/python/dtTriggerPhase2PrimitiveDigis_cfi.py
+++ b/L1Trigger/DTPhase2Trigger/python/dtTriggerPhase2PrimitiveDigis_cfi.py
@@ -32,7 +32,8 @@ dtTriggerPhase2PrimitiveDigis = cms.EDProducer("DTTrigPhase2Prod",
                                                #RPC
                                                rpcRecHits = cms.untracked.InputTag("rpcRecHits"),
                                                useRPC = cms.untracked.bool(False),
-                                               max_quality_to_overwrite_t0 = cms.untracked.int32(9) # will use RPC  to set 't0' for TP with quality < max_quality_to_overwrite_t0
+                                               max_quality_to_overwrite_t0 = cms.untracked.int32(9), # will use RPC  to set 't0' for TP with quality < max_quality_to_overwrite_t0
+                                               storeAllRPCHits = cms.untracked.bool(False)
                                                )
 
 dtTriggerPhase2PrimitiveDigis.HoughGrouping      = HoughGrouping

--- a/L1Trigger/DTPhase2Trigger/src/DTTrigPhase2Prod.cc
+++ b/L1Trigger/DTPhase2Trigger/src/DTTrigPhase2Prod.cc
@@ -367,6 +367,8 @@ void DTTrigPhase2Prod::produce(Event & iEvent, const EventSetup& iEventSetup){
         rpc_integrator->initialise(iEventSetup);
         rpc_integrator->translateRPC(rpcRecHits);
         rpc_integrator->confirmDT(correlatedMetaPrimitives, shift_back);
+        rpc_integrator->makeRPConlySegments();
+        rpc_integrator->removeRPCHitsMatched();
     }
 
     /// STORING RESULTs 
@@ -431,6 +433,7 @@ void DTTrigPhase2Prod::endRun(edm::Run const& iRun, const edm::EventSetup& iEven
   mpathqualityenhancer->finish();
   mpathredundantfilter->finish();
   mpathassociator->finish();
+  rpc_integrator->finish();
 };
 
 

--- a/L1Trigger/DTPhase2Trigger/src/DTTrigPhase2Prod.cc
+++ b/L1Trigger/DTPhase2Trigger/src/DTTrigPhase2Prod.cc
@@ -364,11 +364,12 @@ void DTTrigPhase2Prod::produce(Event & iEvent, const EventSetup& iEventSetup){
     // RPC integration
     if(useRPC) {
         if (debug) std::cout << "Start integrating RPC" << std::endl;
-        rpc_integrator->initialise(iEventSetup);
-        rpc_integrator->translateRPC(rpcRecHits);
-        rpc_integrator->confirmDT(correlatedMetaPrimitives, shift_back);
-        rpc_integrator->makeRPConlySegments();
-        rpc_integrator->removeRPCHitsMatched();
+        rpc_integrator->initialise(iEventSetup, shift_back);
+        rpc_integrator->prepareMetaPrimitives(rpcRecHits);
+        rpc_integrator->matchWithDTAndUseRPCTime(correlatedMetaPrimitives);
+        rpc_integrator->makeRPCOnlySegments();
+        rpc_integrator->storeRPCSingleHits();
+        rpc_integrator->removeRPCHitsUsed();
     }
 
     /// STORING RESULTs 

--- a/L1Trigger/DTPhase2Trigger/src/RPCIntegrator.cc
+++ b/L1Trigger/DTPhase2Trigger/src/RPCIntegrator.cc
@@ -113,8 +113,9 @@ void RPCIntegrator::confirmDT(std::vector<metaPrimitive> & dt_metaprimitives, do
         if (bestMatch_rpcRecHit) {
             (*dt_metaprimitive).rpcFlag = 4;
             if ((*dt_metaprimitive).quality < m_max_quality_to_overwrite_t0){
-                (*dt_metaprimitive).t0 = bestMatch_rpcRecHit->t0() + 25 * shift_back; // Overwriting t0 will propagates to BX since it is defined by round((*metaPrimitiveIt).t0/25.)-shift_back
+                (*dt_metaprimitive).t0 = bestMatch_rpcRecHit->t0() + 25 * shift_back; // Overwriting t0 will propagate to BX since it is defined by round((*metaPrimitiveIt).t0/25.)-shift_back
                                                                                       // but we need to add this shift back since all RPC chamber time is centered at 0 for prompt muon
+                //(*dt_metaprimitive).phiB = bestMatch_rpcRecHit->phi() - dt_metaprimitive->phi; // Use to fine tune the phi matching window
                 (*dt_metaprimitive).rpcFlag = 1;
             }
         }

--- a/L1Trigger/DTPhase2Trigger/src/RPCIntegrator.cc
+++ b/L1Trigger/DTPhase2Trigger/src/RPCIntegrator.cc
@@ -5,6 +5,8 @@
 
 #include <Geometry/Records/interface/MuonGeometryRecord.h>
 
+#include <math.h>
+
 RPCIntegrator::RPCIntegrator(const edm::ParameterSet& pset){
     m_debug = pset.getUntrackedParameter<Bool_t>("debug");
     if (m_debug) std::cout <<"RPCIntegrator constructor" << std::endl;
@@ -24,6 +26,25 @@ void RPCIntegrator::initialise(const edm::EventSetup& iEventSetup) {
     iEventSetup.get<MuonGeometryRecord>().get(m_rpcGeo);
 }
 
+void RPCIntegrator::finish() {
+    return;
+}
+
+void RPCIntegrator::removeRPCHitsMatched() {
+    if (m_debug) std::cout << "RPCIntegrator removeRPCHitsMatched method" << std::endl;
+    if (!m_storeAllRPCHits){ // Remove RPC hit attached to a DT or RPC segment if required by user (avoid having two TP's corresponding to the same physical hit)
+        auto rpcRecHit_translated = rpcRecHits_translated.begin();
+        while (rpcRecHit_translated != rpcRecHits_translated.end()) {
+            if (rpcRecHit_translated->rpcFlag() == 5) {
+                rpcRecHit_translated = rpcRecHits_translated.erase(rpcRecHit_translated);
+            }
+            else {
+                ++rpcRecHit_translated;
+            }
+        }
+    }
+}
+
 GlobalPoint RPCIntegrator::getRPCGlobalPosition(RPCDetId rpcId, const RPCRecHit& rpcIt) const{
 
   RPCDetId rpcid = RPCDetId(rpcId);
@@ -36,7 +57,8 @@ GlobalPoint RPCIntegrator::getRPCGlobalPosition(RPCDetId rpcId, const RPCRecHit&
 
 void RPCIntegrator::translateRPC(edm::Handle<RPCRecHitCollection> rpcRecHits) {
     rpcRecHits_translated.clear();
-    for (RPCRecHitCollection::const_iterator rpcIt = rpcRecHits->begin(); rpcIt != rpcRecHits->end(); rpcIt++) {
+    //for (RPCRecHitCollection::const_iterator rpcIt = rpcRecHits->begin(); rpcIt != rpcRecHits->end(); rpcIt++) {
+    for (auto rpcIt = rpcRecHits->begin(); rpcIt != rpcRecHits->end(); rpcIt++) {
         // Retrieve RPC info and translate it to DT convention if needed
         int rpc_bx = rpcIt->BunchX();
         int rpc_time = int(rpcIt->time());
@@ -59,7 +81,8 @@ void RPCIntegrator::translateRPC(edm::Handle<RPCRecHitCollection> rpcRecHits) {
             if (rpc_global_phi >= 0) rpc_localDT_phi = int((rpc_global_phi - (rpcDetId.sector() - 1) * Geom::pi() / 6.) * m_dt_phi_granularity);
             else rpc_localDT_phi = int((rpc_global_phi + (13 - rpcDetId.sector()) * Geom::pi() / 6.) * m_dt_phi_granularity);
         }
-        int rpc_phiB = -100000; // single hit has no phiB, DT phiB ranges approx from -1500 to 1500
+        rpc_localDT_phi = rpc_localDT_phi - 0.5235988 * (rpc_dt_sector - 1);
+        int rpc_phiB = rpc_global_phi; // single hit has no phiB, DT phiB ranges approx from -1500 to 1500
         int rpc_quality = -1; // to be decided
         int rpc_index = 0;
         int rpc_flag = 3; // only single hit for now
@@ -70,7 +93,7 @@ void RPCIntegrator::translateRPC(edm::Handle<RPCRecHitCollection> rpcRecHits) {
                         rpc_station,
                         rpc_layer, //this would be the layer in the new dataformat
                         rpc_localDT_phi,
-                        rpc_phiB,
+                        rpc_phiB, // temporarily store global phi there because it is useful to compute phiB later on
                         rpc_quality,
                         rpc_index,
                         rpc_time,
@@ -81,30 +104,29 @@ void RPCIntegrator::translateRPC(edm::Handle<RPCRecHitCollection> rpcRecHits) {
 }
 
 L1Phase2MuDTPhDigi* RPCIntegrator::matchDTwithRPC(metaPrimitive* dt_metaprimitive, double shift_back) {
-    int dt_bx = (int)round(dt_metaprimitive->t0/25.) - shift_back;
+    int dt_bx = (int)round(dt_metaprimitive->t0/25.) - shift_back;// because at this stage the BX of metaprimitive is not yet computed...
     DTChamberId dt_chId = DTChamberId(dt_metaprimitive->rawId);
     int sectorTP = dt_chId.sector();
     if (sectorTP == 13) sectorTP = 4;
     if (sectorTP == 14) sectorTP = 10;
     sectorTP = sectorTP - 1;
     L1Phase2MuDTPhDigi* bestMatch_rpcRecHit = NULL;
-    auto bestMatch_rpcRecHit_idx = rpcRecHits_translated.begin();
     float min_dPhi = std::numeric_limits<float>::max();
     for (auto rpcRecHit_translated = rpcRecHits_translated.begin(); rpcRecHit_translated != rpcRecHits_translated.end(); rpcRecHit_translated++) {
-        if (rpcRecHit_translated->whNum() == dt_chId.wheel() && rpcRecHit_translated->stNum() == dt_chId.station() && rpcRecHit_translated->scNum() == sectorTP && std::abs(rpcRecHit_translated->bxNum() - dt_bx) <= m_bx_window) {//FIXME improve DT/RPC matching
-            //if (min_dPhi != std::numeric_limits<float>::max()){
-            //    std::cout << "More than one match for DT/RPC" << dt_chId << std::endl;
-            //}
+        if (rpcRecHit_translated->whNum() == dt_chId.wheel() 
+                && rpcRecHit_translated->stNum() == dt_chId.station() 
+                && rpcRecHit_translated->scNum() == sectorTP
+                && std::abs(rpcRecHit_translated->bxNum() - dt_bx) <= m_bx_window) {
+            //FIXME improve DT/RPC matching
             // Select the RPC hit closest in phi to the DT meta primitive
             if (std::abs(rpcRecHit_translated->phi() - dt_metaprimitive->phi) < min_dPhi){
                 min_dPhi = std::abs(rpcRecHit_translated->phi() - dt_metaprimitive->phi);
                 bestMatch_rpcRecHit = &*rpcRecHit_translated;
-                bestMatch_rpcRecHit_idx = rpcRecHit_translated;
             }
         }
     }
-    if (bestMatch_rpcRecHit and !m_storeAllRPCHits){
-        rpcRecHits_translated.erase(bestMatch_rpcRecHit_idx);
+    if (bestMatch_rpcRecHit){
+        bestMatch_rpcRecHit->setRpcFlag(5);
     }
     return bestMatch_rpcRecHit;
 }
@@ -123,3 +145,63 @@ void RPCIntegrator::confirmDT(std::vector<metaPrimitive> & dt_metaprimitives, do
         }
     }
 }
+
+void RPCIntegrator::makeRPConlySegments() {
+    //int nmatch = 0;
+    //int nhit = 0; 
+    std::vector<L1Phase2MuDTPhDigi> rpc_only_segments;
+    for (auto rpcRecHit_translated = rpcRecHits_translated.begin(); rpcRecHit_translated != rpcRecHits_translated.end(); rpcRecHit_translated++) {
+        if (rpcRecHit_translated->stNum() > 2 || rpcRecHit_translated->slNum() != 1 || (rpcRecHit_translated->rpcFlag() == 5 && !m_storeAllRPCHits)) continue; // only one RPC layer in station three and four && avoid duplicating pairs && avoid building RPC only segment if DT segment was already there
+        float min_dPhi = std::numeric_limits<float>::max();
+        L1Phase2MuDTPhDigi* bestMatch_rpcRecHit = NULL;
+        //nhit++;
+        for (auto rpcRecHit_translated_bis = rpcRecHits_translated.begin(); rpcRecHit_translated_bis != rpcRecHits_translated.end(); rpcRecHit_translated_bis++) {
+            if (rpcRecHit_translated_bis->stNum() ==  rpcRecHit_translated->stNum() 
+                    && rpcRecHit_translated_bis->whNum() == rpcRecHit_translated->whNum()
+                    && rpcRecHit_translated_bis->slNum() != rpcRecHit_translated->slNum()
+                    && rpcRecHit_translated_bis->scNum() != rpcRecHit_translated->scNum()
+                    && rpcRecHit_translated_bis->bxNum() != rpcRecHit_translated->bxNum()
+                    && (rpcRecHit_translated_bis->rpcFlag() != 5 || m_storeAllRPCHits) ) { // avoid building RPC only segment with a hit already matched to DT, except if one aske to store all RPC info 
+
+                float tmp_dPhi = rpcRecHit_translated_bis->phi() - rpcRecHit_translated->phi();
+                if (std::abs(tmp_dPhi) < std::abs(min_dPhi)) {
+                    min_dPhi = tmp_dPhi;
+                    bestMatch_rpcRecHit = &*rpcRecHit_translated_bis;
+                }
+            }
+        }
+        if (bestMatch_rpcRecHit) {
+            //nmatch++;
+            rpcRecHit_translated->setRpcFlag(5);
+            bestMatch_rpcRecHit->setRpcFlag(5);
+            int phi = (rpcRecHit_translated->phi() + bestMatch_rpcRecHit->phi())/2.0;
+            int t0 = (rpcRecHit_translated->t0() + bestMatch_rpcRecHit->t0())/2.0;
+            int phib = getPhiBending(&*rpcRecHit_translated, bestMatch_rpcRecHit);
+            L1Phase2MuDTPhDigi rpc_only_segment  = L1Phase2MuDTPhDigi(bestMatch_rpcRecHit->bxNum(), bestMatch_rpcRecHit->whNum(), bestMatch_rpcRecHit->scNum(), bestMatch_rpcRecHit->stNum(), 0, phi, phib, -1, 0, t0, -1, 2); 
+            rpc_only_segments.push_back(rpc_only_segment);
+        }
+    }
+    rpcRecHits_translated.insert(rpcRecHits_translated.end(), rpc_only_segments.begin(), rpc_only_segments.end());
+    //std::cout << "Nhit: " << nhit <<  " Nmatch: " << nmatch << std::endl;
+}
+
+int RPCIntegrator::getPhiBending(L1Phase2MuDTPhDigi* rpc_hit_1, L1Phase2MuDTPhDigi* rpc_hit_2) {
+    int xin = getLocalX((rpc_hit_1->phi() << 2), rpc_hit_1->slNum(), rpc_hit_1->stNum());
+    int xout = getLocalX((rpc_hit_2->phi() << 2), rpc_hit_2->slNum(), rpc_hit_2->stNum());
+    double slope = (xin - xout)/23.5;
+    double psi = atan(slope);
+    // Pay attentiont to the fact that global phi was stored in the phiBending member for convenience
+    int phi = rpc_hit_1->phiBend();
+    double phiB = hasPosRF_rpc(rpc_hit_1->whNum(), rpc_hit_1->scNum()) ? psi - phi : -psi - phi; // FIXME chose arbitralily one of the phi, need to derive it in the middle of the station
+    return phiB;
+}
+
+int RPCIntegrator::getLocalX(int phi_local_dt_tpformat, int layer, int station) {
+    double x =  R[station - 1][layer - 1] * tan(phi_local_dt_tpformat);
+    return x;
+}
+
+bool RPCIntegrator::hasPosRF_rpc(int wh, int sec) {
+    return (wh > 0 || (wh == 0 && sec % 4 > 1));
+}
+

--- a/L1Trigger/DTPhase2Trigger/src/RPCIntegrator.cc
+++ b/L1Trigger/DTPhase2Trigger/src/RPCIntegrator.cc
@@ -12,6 +12,7 @@ RPCIntegrator::RPCIntegrator(const edm::ParameterSet& pset){
     if (m_debug) std::cout <<"RPCIntegrator constructor" << std::endl;
     m_max_quality_to_overwrite_t0 = pset.getUntrackedParameter<int>("max_quality_to_overwrite_t0");
     m_bx_window = pset.getUntrackedParameter<int>("bx_window");
+    m_phi_window = pset.getUntrackedParameter<double>("phi_window");
     m_storeAllRPCHits = pset.getUntrackedParameter<bool>("storeAllRPCHits");
 }
 
@@ -19,23 +20,111 @@ RPCIntegrator::~RPCIntegrator() {
     if (m_debug) std::cout <<"RPCIntegrator destructor" << std::endl;
 }
 
-void RPCIntegrator::initialise(const edm::EventSetup& iEventSetup) {
+void RPCIntegrator::initialise(const edm::EventSetup& iEventSetup, double shift_back_fromDT) {
     if (m_debug) std::cout << "RPCIntegrator initialisation" << std::endl;
     
     if (m_debug) std::cout << "Getting RPC geometry" << std::endl;
     iEventSetup.get<MuonGeometryRecord>().get(m_rpcGeo);
+
+    iEventSetup.get<MuonGeometryRecord>().get(m_dtGeo);
+    shift_back = shift_back_fromDT;
 }
 
 void RPCIntegrator::finish() {
     return;
 }
 
-void RPCIntegrator::removeRPCHitsMatched() {
-    if (m_debug) std::cout << "RPCIntegrator removeRPCHitsMatched method" << std::endl;
+void RPCIntegrator::prepareMetaPrimitives(edm::Handle<RPCRecHitCollection> rpcRecHits) {
+    rpc_metaprimitives.clear();
+    rpcRecHits_translated.clear();
+    for (auto rpcIt = rpcRecHits->begin(); rpcIt != rpcRecHits->end(); rpcIt++) {
+        RPCDetId rpcDetId = (RPCDetId)(*rpcIt).rpcId();
+        GlobalPoint global_position = getRPCGlobalPosition(rpcDetId, *rpcIt);
+        int rpc_region = rpcDetId.region();
+        if(rpc_region != 0 ) continue; // Region = 0 Barrel
+        rpc_metaprimitives.push_back(rpc_metaprimitive(rpcDetId, &*rpcIt, global_position, 3, rpcIt->BunchX() + 20, rpcIt->time() + 20 * 25)); // set everyone to rpc single hit not matched to DT flag for now
+        // if dt bx centered at zero again
+        //rpc_metaprimitives.push_back(rpc_metaprimitive(rpcDetId, &*rpcIt, global_position, 3)); // set everyone to rpc single hit not matched to DT flag for now
+    }
+}
+void RPCIntegrator::matchWithDTAndUseRPCTime(std::vector<metaPrimitive> & dt_metaprimitives) {
+    for (auto dt_metaprimitive = dt_metaprimitives.begin(); dt_metaprimitive != dt_metaprimitives.end(); dt_metaprimitive++) {
+        rpc_metaprimitive* bestMatch_rpcRecHit = matchDTwithRPC(&*dt_metaprimitive);
+        if (bestMatch_rpcRecHit) {
+            (*dt_metaprimitive).rpcFlag = 4;
+            if ((*dt_metaprimitive).quality < m_max_quality_to_overwrite_t0){
+                (*dt_metaprimitive).t0 = bestMatch_rpcRecHit->rpc_t0 + 25 * shift_back; // Overwriting t0 will propagate to BX since it is defined by round((*metaPrimitiveIt).t0/25.)-shift_back
+                //(*dt_metaprimitive).t0 = bestMatch_rpcRecHit->rpc_cluster->time() + 25 * shift_back; // Overwriting t0 will propagate to BX since it is defined by round((*metaPrimitiveIt).t0/25.)-shift_back
+                                                                                      // but we need to add this shift back since all RPC chamber time is centered at 0 for prompt muon
+                //(*dt_metaprimitive).phiB = getPhi_DT_MP_conv(bestMatch_rpcRecHit->global_position.phi(), bestMatch_rpcRecHit->rpc_id.sector()) - dt_metaprimitive->phi; // Use to fine tune the phi matching window (just need somewhere top store the deltaPhi to plot in with the output collection
+                (*dt_metaprimitive).rpcFlag = 1;
+            }
+        }
+    }
+}
+
+void RPCIntegrator::makeRPCOnlySegments() {
+    std::vector<L1Phase2MuDTPhDigi> rpc_only_segments;
+    for (auto rpc_mp_it_layer1 = rpc_metaprimitives.begin(); rpc_mp_it_layer1 != rpc_metaprimitives.end(); rpc_mp_it_layer1++) {
+        RPCDetId rpc_id_l1 = rpc_mp_it_layer1->rpc_id;
+        const RPCRecHit* rpc_cluster_l1 = rpc_mp_it_layer1->rpc_cluster;
+        GlobalPoint rpc_gp_l1 = rpc_mp_it_layer1->global_position;
+        if (rpc_id_l1.station() > 2 || rpc_id_l1.layer() != 1 || (rpc_mp_it_layer1->rpcFlag == 5 && !m_storeAllRPCHits)) continue; // only one RPC layer in station three and four && avoid duplicating pairs && avoid building RPC only segment if DT segment was already there
+        //if (rpc_id_l1.station() > 2 || rpc_id_l1.layer() != 1 || (rpc_mp_it_layer1->rpcFlag == 5 && !m_storeAllRPCHits) || rpc_mp_it_layer1->rpcFlag == 6) continue; // only one RPC layer in station three and four && avoid duplicating pairs && avoid building RPC only segment if DT segment was already there && allow a cluster to be used in one segment only
+        int min_dPhi = std::numeric_limits<int>::max();
+        rpc_metaprimitive* bestMatch_rpc_mp_layer2 = NULL;
+        for (auto rpc_mp_it_layer2 = rpc_metaprimitives.begin(); rpc_mp_it_layer2 != rpc_metaprimitives.end(); rpc_mp_it_layer2++) {
+            RPCDetId rpc_id_l2 = rpc_mp_it_layer2->rpc_id;
+            const RPCRecHit* rpc_cluster_l2 = rpc_mp_it_layer2->rpc_cluster;
+            GlobalPoint rpc_gp_l2 = rpc_mp_it_layer2->global_position;
+            if (rpc_id_l2.station() == rpc_id_l1.station()
+                    && rpc_id_l2.ring() == rpc_id_l1.ring()
+                    && rpc_id_l2.layer() != rpc_id_l1.layer() // ensure to have layer 1 --> layer 2
+                    && rpc_id_l2.sector() == rpc_id_l1.sector()
+                    && rpc_cluster_l2->BunchX() == rpc_cluster_l1->BunchX()
+                    && (rpc_mp_it_layer2->rpcFlag != 5 || m_storeAllRPCHits)) { // avoid building RPC only segment with a hit already matched to DT, except if one aske to store all RPC info
+                    //&& rpc_mp_it_layer2->rpcFlag != 6) {
+                float tmp_dPhi = rpc_gp_l1.phi() - rpc_gp_l2.phi();
+                if (std::abs(tmp_dPhi) < std::abs(min_dPhi)) {
+                    min_dPhi = tmp_dPhi;
+                    bestMatch_rpc_mp_layer2 = &*rpc_mp_it_layer2;
+                }
+            }
+        }
+        if (bestMatch_rpc_mp_layer2) {
+            rpc_mp_it_layer1->rpcFlag = 6; // need a new flag (will be removed later) to differentiate between "has been matched to DT" and "Has been used in an RPC only segment"
+            bestMatch_rpc_mp_layer2->rpcFlag = 6;
+            double phiB = getPhiBending(&*rpc_mp_it_layer1, &*bestMatch_rpc_mp_layer2);
+            //double global_phi = (rpc_mp_it_layer1->global_position.phi() + bestMatch_rpc_mp_layer2->global_position.phi()) / 2.0; // does not work...
+            // FIXME define the phi of the segment at the middle of it?
+            double global_phi = rpc_mp_it_layer1->global_position.phi(); // Arbitrarily choose the phi from layer 1
+            //double t0 = (rpc_mp_it_layer1->rpc_cluster->time() + bestMatch_rpc_mp_layer2->rpc_cluster->time()) / 2;
+            double t0 = (rpc_mp_it_layer1->rpc_t0 + bestMatch_rpc_mp_layer2->rpc_t0) / 2;
+            //L1Phase2MuDTPhDigi rpc_only_segment  = createL1Phase2MuDTPhDigi(rpc_id_l1, rpc_mp_it_layer1->rpc_cluster->BunchX(), t0, global_phi, phiB, 2); // RPC only segment have rpcFlag==2
+            L1Phase2MuDTPhDigi rpc_only_segment  = createL1Phase2MuDTPhDigi(rpc_id_l1, rpc_mp_it_layer1->rpc_bx, t0, global_phi, phiB, 2); // RPC only segment have rpcFlag==2
+            rpc_only_segments.push_back(rpc_only_segment);
+        }
+    }
+    rpcRecHits_translated.insert(rpcRecHits_translated.end(), rpc_only_segments.begin(), rpc_only_segments.end());
+}
+
+void RPCIntegrator::storeRPCSingleHits() {
+    for (auto rpc_mp_it = rpc_metaprimitives.begin(); rpc_mp_it != rpc_metaprimitives.end(); rpc_mp_it++){
+        //const RPCRecHit* rpc_hit = rpc_mp_it->rpc_cluster;
+        RPCDetId rpcDetId = rpc_mp_it->rpc_id;
+        if (rpc_mp_it->rpcFlag == 6) rpc_mp_it->rpcFlag = 5;
+        L1Phase2MuDTPhDigi rpc_out = createL1Phase2MuDTPhDigi(rpcDetId, rpc_mp_it->rpc_bx, rpc_mp_it->rpc_t0, rpc_mp_it->global_position.phi(), -10000, rpc_mp_it->rpcFlag);
+        //L1Phase2MuDTPhDigi rpc_out = createL1Phase2MuDTPhDigi(rpcDetId, rpc_hit->BunchX(), rpc_hit->time(), rpc_mp_it->global_position.phi(), -10000, rpc_mp_it->rpcFlag);
+        rpcRecHits_translated.push_back(rpc_out);
+    }
+}
+
+void RPCIntegrator::removeRPCHitsUsed() {
+    if (m_debug) std::cout << "RPCIntegrator removeRPCHitsUsed method" << std::endl;
     if (!m_storeAllRPCHits){ // Remove RPC hit attached to a DT or RPC segment if required by user (avoid having two TP's corresponding to the same physical hit)
         auto rpcRecHit_translated = rpcRecHits_translated.begin();
         while (rpcRecHit_translated != rpcRecHits_translated.end()) {
-            if (rpcRecHit_translated->rpcFlag() == 5) {
+            if (rpcRecHit_translated->rpcFlag() == 5 || rpcRecHit_translated->rpcFlag() == 6) {
                 rpcRecHit_translated = rpcRecHits_translated.erase(rpcRecHit_translated);
             }
             else {
@@ -45,163 +134,102 @@ void RPCIntegrator::removeRPCHitsMatched() {
     }
 }
 
-GlobalPoint RPCIntegrator::getRPCGlobalPosition(RPCDetId rpcId, const RPCRecHit& rpcIt) const{
+rpc_metaprimitive* RPCIntegrator::matchDTwithRPC(metaPrimitive* dt_metaprimitive) {
+    // metaprimitive dtChId is still in convention with [1 - 12]
+    int dt_bx = (int)round(dt_metaprimitive->t0/25.) - shift_back;// because at this stage the BX of metaprimitive is not yet computed... will also have to subtract 20*25 ns because of the recent change
+    DTChamberId dt_chId = DTChamberId(dt_metaprimitive->rawId);
+    int dt_sector = dt_chId.sector();
+    if (dt_sector == 13) dt_sector = 4;
+    if (dt_sector == 14) dt_sector = 10;
+    rpc_metaprimitive* bestMatch_rpcRecHit = NULL;
+    float min_dPhi = std::numeric_limits<float>::max();
+    for (auto rpc_mp_it = rpc_metaprimitives.begin(); rpc_mp_it != rpc_metaprimitives.end(); rpc_mp_it++) {
+        RPCDetId rpc_det_id = rpc_mp_it->rpc_id;
+        //const RPCRecHit* rpc_cluster_toBeMatched = rpc_mp_it->rpc_cluster;
+        if (rpc_det_id.ring() == dt_chId.wheel() // ring() in barrel RPC corresponds to the wheel
+                && rpc_det_id.station() == dt_chId.station()
+                && rpc_det_id.sector() == dt_sector
+                && std::abs(rpc_mp_it->rpc_bx - dt_bx) <= m_bx_window) {
+            //FIXME improve DT/RPC matching e.g. use 2D position instead of phi, use segment direction to extrapolate, etc.
+            // Select the RPC hit closest in phi to the DT meta primitive
 
+            //int rpc_phi_dtConv = getPhi_DT_MP_conv(rpc_mp_it->global_position.phi(), rpc_det_id.sector(), false);
+            int delta_phi = (int)round((getPhi_DT_MP_conv(rpc_mp_it->global_position.phi(), rpc_det_id.sector()) - dt_metaprimitive->phi) * m_dt_phiB_granularity); // just a trick to apply the phi window cut on what could be accessed to fine tune it
+            //if (std::abs(rpc_phi_dtConv - dt_metaprimitive->phi) < min_dPhi && delta_phi < m_phi_window){
+            if (std::abs(delta_phi) < min_dPhi && std::abs(delta_phi) < m_phi_window){
+                min_dPhi = std::abs(delta_phi);
+                bestMatch_rpcRecHit = &*rpc_mp_it;
+            }
+        }
+    }
+    if (bestMatch_rpcRecHit){
+        bestMatch_rpcRecHit->rpcFlag = 5;
+    }
+    return bestMatch_rpcRecHit;
+}
+
+L1Phase2MuDTPhDigi RPCIntegrator::createL1Phase2MuDTPhDigi(RPCDetId rpcDetId, int rpc_bx, double rpc_time, double rpc_global_phi, double phiB, int rpc_flag) {
+    if (m_debug) std::cout << "Creating DT TP out of RPC recHits" << std::endl;
+    int rpc_wheel = rpcDetId.ring(); // In barrel, wheel is accessed via ring() method ([-2,+2])
+    int trigger_sector = rpcDetId.sector()-1; // DT Trigger sector:[0,11] while RPC sector:[1,12]
+    int rpc_station = rpcDetId.station();
+    int rpc_layer = rpcDetId.layer();
+    int rpc_trigger_phi = (phiB == -10000) ? phiB : getPhiInDTTPFormat(rpc_global_phi, rpcDetId.sector());
+    int rpc_trigger_phiB = (int)round(phiB * m_dt_phiB_granularity);
+    int rpc_quality = -1; // dummy for rpc
+    int rpc_index = 0; // dummy for rpc
+    return L1Phase2MuDTPhDigi(rpc_bx,
+                    rpc_wheel,
+                    trigger_sector,
+                    rpc_station,
+                    rpc_layer, //this would be the layer in the new dataformat
+                    rpc_trigger_phi,
+                    rpc_trigger_phiB,
+                    rpc_quality,
+                    rpc_index,
+                    rpc_time,
+                    -1, // no chi2 for RPC
+                    rpc_flag);
+}
+
+
+double RPCIntegrator::getPhiBending(rpc_metaprimitive* rpc_hit_1, rpc_metaprimitive* rpc_hit_2) {
+    // Adaptation of https://github.com/dtp2-tpg-am/cmssw/blob/AM_106X_dev/L1Trigger/DTPhase2Trigger/src/MuonPathAssociator.cc#L189
+    DTChamberId DT_chamber(rpc_hit_1->rpc_id.ring(), rpc_hit_1->rpc_id.station(), rpc_hit_1->rpc_id.sector());
+    LocalPoint lp_rpc_hit_1_dtconv = m_dtGeo->chamber(DT_chamber)->toLocal(rpc_hit_1->global_position);
+    LocalPoint lp_rpc_hit_2_dtconv = m_dtGeo->chamber(DT_chamber)->toLocal(rpc_hit_2->global_position);
+    double slope = (lp_rpc_hit_1_dtconv.x() - lp_rpc_hit_2_dtconv.x()) / distance_between_two_rpc_layers;
+    double average_x = (lp_rpc_hit_1_dtconv.x() + lp_rpc_hit_2_dtconv.x()) / 2;
+    GlobalPoint seg_middle_global = m_dtGeo->chamber(DT_chamber)->toGlobal(LocalPoint(average_x, 0., 0.)); // for station 1 and 2, z = 0
+    double seg_phi = getPhi_DT_MP_conv(seg_middle_global.phi(), rpc_hit_1->rpc_id.sector());
+    double psi = atan(slope);
+    double phiB = hasPosRF_rpc(rpc_hit_1->rpc_id.ring(), rpc_hit_1->rpc_id.sector()) ? psi - seg_phi : -psi - seg_phi;
+    return phiB;
+}
+
+int RPCIntegrator::getPhiInDTTPFormat(double rpc_global_phi, int rpcSector){
+    double rpc_localDT_phi;
+    rpc_localDT_phi = getPhi_DT_MP_conv(rpc_global_phi, rpcSector) * m_dt_phi_granularity;
+    return (int)round(rpc_localDT_phi);
+}
+
+double RPCIntegrator::getPhi_DT_MP_conv(double rpc_global_phi, int rpcSector){
+    // Adaptation of https://github.com/cms-sw/cmssw/blob/master/L1Trigger/L1TTwinMux/src/RPCtoDTTranslator.cc#L349
+    if (rpcSector == 1) return rpc_global_phi;
+    else {
+        if (rpc_global_phi >= 0) return rpc_global_phi - (rpcSector - 1) * Geom::pi() / 6.;
+        else return rpc_global_phi + (13 - rpcSector) * Geom::pi() / 6.;
+    }
+}
+
+GlobalPoint RPCIntegrator::getRPCGlobalPosition(RPCDetId rpcId, const RPCRecHit& rpcIt) const{
   RPCDetId rpcid = RPCDetId(rpcId);
   const LocalPoint& rpc_lp = rpcIt.localPosition();
   const GlobalPoint& rpc_gp = m_rpcGeo->idToDet(rpcid)->surface().toGlobal(rpc_lp);
 
   return rpc_gp;
-
-}
-
-void RPCIntegrator::translateRPC(edm::Handle<RPCRecHitCollection> rpcRecHits) {
-    rpcRecHits_translated.clear();
-    //for (RPCRecHitCollection::const_iterator rpcIt = rpcRecHits->begin(); rpcIt != rpcRecHits->end(); rpcIt++) {
-    for (auto rpcIt = rpcRecHits->begin(); rpcIt != rpcRecHits->end(); rpcIt++) {
-        // Retrieve RPC info and translate it to DT convention if needed
-        int rpc_bx = rpcIt->BunchX();
-        int rpc_time = int(rpcIt->time());
-        RPCDetId rpcDetId = (RPCDetId)(*rpcIt).rpcId();
-        if (m_debug) std::cout << "Getting RPC info from : " << rpcDetId << std::endl;
-        int rpc_region = rpcDetId.region();
-        if(rpc_region != 0 ) continue; // Region = 0 Barrel
-        int rpc_wheel = rpcDetId.ring(); // In barrel, wheel is accessed via ring() method ([-2,+2])
-        int rpc_dt_sector = rpcDetId.sector()-1; // DT sector:[0,11] while RPC sector:[1,12]
-        int rpc_station = rpcDetId.station();
-        int rpc_layer = rpcDetId.layer();
-
-        if (m_debug) std::cout << "Getting RPC global point and translating to DT local coordinates" << std::endl;
-        GlobalPoint rpc_gp = getRPCGlobalPosition(rpcDetId, *rpcIt);
-        double rpc_global_phi = rpc_gp.phi();
-        int rpc_localDT_phi = std::numeric_limits<int>::min();
-        // Adaptation of https://github.com/cms-sw/cmssw/blob/master/L1Trigger/L1TTwinMux/src/RPCtoDTTranslator.cc#L349
-        if (rpcDetId.sector() == 1) rpc_localDT_phi = int(rpc_global_phi * m_dt_phi_granularity);
-        else {
-            if (rpc_global_phi >= 0) rpc_localDT_phi = int((rpc_global_phi - (rpcDetId.sector() - 1) * Geom::pi() / 6.) * m_dt_phi_granularity);
-            else rpc_localDT_phi = int((rpc_global_phi + (13 - rpcDetId.sector()) * Geom::pi() / 6.) * m_dt_phi_granularity);
-        }
-        rpc_localDT_phi = rpc_localDT_phi - 0.5235988 * (rpc_dt_sector - 1);
-        int rpc_phiB = rpc_global_phi; // single hit has no phiB, DT phiB ranges approx from -1500 to 1500
-        int rpc_quality = -1; // to be decided
-        int rpc_index = 0;
-        int rpc_flag = 3; // only single hit for now
-        if (m_debug) std::cout << "Creating DT TP out of RPC recHits" << std::endl;
-        rpcRecHits_translated.push_back(L1Phase2MuDTPhDigi(rpc_bx,
-                        rpc_wheel,
-                        rpc_dt_sector,
-                        rpc_station,
-                        rpc_layer, //this would be the layer in the new dataformat
-                        rpc_localDT_phi,
-                        rpc_phiB, // temporarily store global phi there because it is useful to compute phiB later on
-                        rpc_quality,
-                        rpc_index,
-                        rpc_time,
-                        -1, // signle hit --> no chi2
-                        rpc_flag
-                        ));
-    }
-}
-
-L1Phase2MuDTPhDigi* RPCIntegrator::matchDTwithRPC(metaPrimitive* dt_metaprimitive, double shift_back) {
-    int dt_bx = (int)round(dt_metaprimitive->t0/25.) - shift_back;// because at this stage the BX of metaprimitive is not yet computed...
-    DTChamberId dt_chId = DTChamberId(dt_metaprimitive->rawId);
-    int sectorTP = dt_chId.sector();
-    if (sectorTP == 13) sectorTP = 4;
-    if (sectorTP == 14) sectorTP = 10;
-    sectorTP = sectorTP - 1;
-    L1Phase2MuDTPhDigi* bestMatch_rpcRecHit = NULL;
-    float min_dPhi = std::numeric_limits<float>::max();
-    for (auto rpcRecHit_translated = rpcRecHits_translated.begin(); rpcRecHit_translated != rpcRecHits_translated.end(); rpcRecHit_translated++) {
-        if (rpcRecHit_translated->whNum() == dt_chId.wheel() 
-                && rpcRecHit_translated->stNum() == dt_chId.station() 
-                && rpcRecHit_translated->scNum() == sectorTP
-                && std::abs(rpcRecHit_translated->bxNum() - dt_bx) <= m_bx_window) {
-            //FIXME improve DT/RPC matching
-            // Select the RPC hit closest in phi to the DT meta primitive
-            if (std::abs(rpcRecHit_translated->phi() - dt_metaprimitive->phi) < min_dPhi){
-                min_dPhi = std::abs(rpcRecHit_translated->phi() - dt_metaprimitive->phi);
-                bestMatch_rpcRecHit = &*rpcRecHit_translated;
-            }
-        }
-    }
-    if (bestMatch_rpcRecHit){
-        bestMatch_rpcRecHit->setRpcFlag(5);
-    }
-    return bestMatch_rpcRecHit;
-}
-
-void RPCIntegrator::confirmDT(std::vector<metaPrimitive> & dt_metaprimitives, double shift_back) {
-    for (auto dt_metaprimitive = dt_metaprimitives.begin(); dt_metaprimitive != dt_metaprimitives.end(); dt_metaprimitive++) {
-        L1Phase2MuDTPhDigi* bestMatch_rpcRecHit = matchDTwithRPC(&*dt_metaprimitive, shift_back);
-        if (bestMatch_rpcRecHit) {
-            (*dt_metaprimitive).rpcFlag = 4;
-            if ((*dt_metaprimitive).quality < m_max_quality_to_overwrite_t0){
-                (*dt_metaprimitive).t0 = bestMatch_rpcRecHit->t0() + 25 * shift_back; // Overwriting t0 will propagate to BX since it is defined by round((*metaPrimitiveIt).t0/25.)-shift_back
-                                                                                      // but we need to add this shift back since all RPC chamber time is centered at 0 for prompt muon
-                //(*dt_metaprimitive).phiB = bestMatch_rpcRecHit->phi() - dt_metaprimitive->phi; // Use to fine tune the phi matching window
-                (*dt_metaprimitive).rpcFlag = 1;
-            }
-        }
-    }
-}
-
-void RPCIntegrator::makeRPConlySegments() {
-    //int nmatch = 0;
-    //int nhit = 0; 
-    std::vector<L1Phase2MuDTPhDigi> rpc_only_segments;
-    for (auto rpcRecHit_translated = rpcRecHits_translated.begin(); rpcRecHit_translated != rpcRecHits_translated.end(); rpcRecHit_translated++) {
-        if (rpcRecHit_translated->stNum() > 2 || rpcRecHit_translated->slNum() != 1 || (rpcRecHit_translated->rpcFlag() == 5 && !m_storeAllRPCHits)) continue; // only one RPC layer in station three and four && avoid duplicating pairs && avoid building RPC only segment if DT segment was already there
-        float min_dPhi = std::numeric_limits<float>::max();
-        L1Phase2MuDTPhDigi* bestMatch_rpcRecHit = NULL;
-        //nhit++;
-        for (auto rpcRecHit_translated_bis = rpcRecHits_translated.begin(); rpcRecHit_translated_bis != rpcRecHits_translated.end(); rpcRecHit_translated_bis++) {
-            if (rpcRecHit_translated_bis->stNum() ==  rpcRecHit_translated->stNum() 
-                    && rpcRecHit_translated_bis->whNum() == rpcRecHit_translated->whNum()
-                    && rpcRecHit_translated_bis->slNum() != rpcRecHit_translated->slNum()
-                    && rpcRecHit_translated_bis->scNum() != rpcRecHit_translated->scNum()
-                    && rpcRecHit_translated_bis->bxNum() != rpcRecHit_translated->bxNum()
-                    && (rpcRecHit_translated_bis->rpcFlag() != 5 || m_storeAllRPCHits) ) { // avoid building RPC only segment with a hit already matched to DT, except if one aske to store all RPC info 
-
-                float tmp_dPhi = rpcRecHit_translated_bis->phi() - rpcRecHit_translated->phi();
-                if (std::abs(tmp_dPhi) < std::abs(min_dPhi)) {
-                    min_dPhi = tmp_dPhi;
-                    bestMatch_rpcRecHit = &*rpcRecHit_translated_bis;
-                }
-            }
-        }
-        if (bestMatch_rpcRecHit) {
-            //nmatch++;
-            rpcRecHit_translated->setRpcFlag(5);
-            bestMatch_rpcRecHit->setRpcFlag(5);
-            int phi = (rpcRecHit_translated->phi() + bestMatch_rpcRecHit->phi())/2.0;
-            int t0 = (rpcRecHit_translated->t0() + bestMatch_rpcRecHit->t0())/2.0;
-            int phib = getPhiBending(&*rpcRecHit_translated, bestMatch_rpcRecHit);
-            L1Phase2MuDTPhDigi rpc_only_segment  = L1Phase2MuDTPhDigi(bestMatch_rpcRecHit->bxNum(), bestMatch_rpcRecHit->whNum(), bestMatch_rpcRecHit->scNum(), bestMatch_rpcRecHit->stNum(), 0, phi, phib, -1, 0, t0, -1, 2); 
-            rpc_only_segments.push_back(rpc_only_segment);
-        }
-    }
-    rpcRecHits_translated.insert(rpcRecHits_translated.end(), rpc_only_segments.begin(), rpc_only_segments.end());
-    //std::cout << "Nhit: " << nhit <<  " Nmatch: " << nmatch << std::endl;
-}
-
-int RPCIntegrator::getPhiBending(L1Phase2MuDTPhDigi* rpc_hit_1, L1Phase2MuDTPhDigi* rpc_hit_2) {
-    int xin = getLocalX((rpc_hit_1->phi() << 2), rpc_hit_1->slNum(), rpc_hit_1->stNum());
-    int xout = getLocalX((rpc_hit_2->phi() << 2), rpc_hit_2->slNum(), rpc_hit_2->stNum());
-    double slope = (xin - xout)/23.5;
-    double psi = atan(slope);
-    // Pay attentiont to the fact that global phi was stored in the phiBending member for convenience
-    int phi = rpc_hit_1->phiBend();
-    double phiB = hasPosRF_rpc(rpc_hit_1->whNum(), rpc_hit_1->scNum()) ? psi - phi : -psi - phi; // FIXME chose arbitralily one of the phi, need to derive it in the middle of the station
-    return phiB;
-}
-
-int RPCIntegrator::getLocalX(int phi_local_dt_tpformat, int layer, int station) {
-    double x =  R[station - 1][layer - 1] * tan(phi_local_dt_tpformat);
-    return x;
 }
 
 bool RPCIntegrator::hasPosRF_rpc(int wh, int sec) {
     return (wh > 0 || (wh == 0 && sec % 4 > 1));
 }
-

--- a/L1Trigger/DTPhase2Trigger/src/RPCIntegrator.cc
+++ b/L1Trigger/DTPhase2Trigger/src/RPCIntegrator.cc
@@ -174,8 +174,8 @@ L1Phase2MuDTPhDigi RPCIntegrator::createL1Phase2MuDTPhDigi(RPCDetId rpcDetId, in
     int trigger_sector = rpcDetId.sector()-1; // DT Trigger sector:[0,11] while RPC sector:[1,12]
     int rpc_station = rpcDetId.station();
     int rpc_layer = rpcDetId.layer();
-    int rpc_trigger_phi = (phiB == -10000) ? phiB : getPhiInDTTPFormat(rpc_global_phi, rpcDetId.sector());
-    int rpc_trigger_phiB = (int)round(phiB * m_dt_phiB_granularity);
+    int rpc_trigger_phi = getPhiInDTTPFormat(rpc_global_phi, rpcDetId.sector());
+    int rpc_trigger_phiB = (phiB == -10000) ? phiB : (int)round(phiB * m_dt_phiB_granularity);
     int rpc_quality = -1; // dummy for rpc
     int rpc_index = 0; // dummy for rpc
     return L1Phase2MuDTPhDigi(rpc_bx,

--- a/L1Trigger/DTPhase2Trigger/src/RPCIntegrator.cc
+++ b/L1Trigger/DTPhase2Trigger/src/RPCIntegrator.cc
@@ -9,6 +9,7 @@ RPCIntegrator::RPCIntegrator(const edm::ParameterSet& pset){
     m_debug = pset.getUntrackedParameter<Bool_t>("debug");
     if (m_debug) std::cout <<"RPCIntegrator constructor" << std::endl;
     m_max_quality_to_overwrite_t0 = pset.getUntrackedParameter<int>("max_quality_to_overwrite_t0");
+    m_storeAllRPCHits = pset.getUntrackedParameter<bool>("storeAllRPCHits");
 }
 
 RPCIntegrator::~RPCIntegrator() {
@@ -85,9 +86,10 @@ L1Phase2MuDTPhDigi* RPCIntegrator::matchDTwithRPC(metaPrimitive* dt_metaprimitiv
     if (sectorTP == 14) sectorTP = 10;
     sectorTP = sectorTP - 1;
     L1Phase2MuDTPhDigi* bestMatch_rpcRecHit = NULL;
+    auto bestMatch_rpcRecHit_idx = rpcRecHits_translated.begin();
     float min_dPhi = std::numeric_limits<float>::max();
     for (auto rpcRecHit_translated = rpcRecHits_translated.begin(); rpcRecHit_translated != rpcRecHits_translated.end(); rpcRecHit_translated++) {
-        if (rpcRecHit_translated->whNum() == dt_chId.wheel() && rpcRecHit_translated->stNum() == dt_chId.station() && rpcRecHit_translated->scNum() == sectorTP) {
+        if (rpcRecHit_translated->whNum() == dt_chId.wheel() && rpcRecHit_translated->stNum() == dt_chId.station() && rpcRecHit_translated->scNum() == sectorTP) {//FIXME improve DT/RPC matching
             //if (min_dPhi != std::numeric_limits<float>::max()){
             //    std::cout << "More than one match for DT/RPC" << dt_chId << std::endl;
             //}
@@ -95,8 +97,12 @@ L1Phase2MuDTPhDigi* RPCIntegrator::matchDTwithRPC(metaPrimitive* dt_metaprimitiv
             if (std::abs(rpcRecHit_translated->phi() - dt_metaprimitive->phi) < min_dPhi){
                 min_dPhi = std::abs(rpcRecHit_translated->phi() - dt_metaprimitive->phi);
                 bestMatch_rpcRecHit = &*rpcRecHit_translated;
+                bestMatch_rpcRecHit_idx = rpcRecHit_translated;
             }
         }
+    }
+    if (bestMatch_rpcRecHit and !m_storeAllRPCHits){
+        rpcRecHits_translated.erase(bestMatch_rpcRecHit_idx);
     }
     return bestMatch_rpcRecHit;
 }

--- a/L1Trigger/DTPhase2Trigger/test/primitivesPhase2Prod_over_dTDigis_and_4Dsegments_cfg_withRPC.py
+++ b/L1Trigger/DTPhase2Trigger/test/primitivesPhase2Prod_over_dTDigis_and_4Dsegments_cfg_withRPC.py
@@ -36,13 +36,14 @@ process.rpcRecHits.rpcDigiLabel = cms.InputTag('simMuonRPCDigis')
 process.load('Configuration.Geometry.GeometryExtended2023D38Reco_cff')
 process.load('Configuration.Geometry.GeometryExtended2023D38_cff')
 process.dtTriggerPhase2PrimitiveDigis.useRPC = True
-process.dtTriggerPhase2PrimitiveDigis.bx_window = 50 # TO BE modified when DT and RPC will have same BX definition...
-process.dtTriggerPhase2PrimitiveDigis.max_quality_to_overwrite_t0 = 9 # strict inequality
-process.dtTriggerPhase2PrimitiveDigis.storeAllRPCHits = True
 process.dtTriggerPhase2PrimitiveDigis.scenario = 0 # 0 for mc, 1 for data, 2 for slice test
+## Parameters that could be optimized (show here the default values)
+#process.dtTriggerPhase2PrimitiveDigis.bx_window = 1 #
+#process.dtTriggerPhase2PrimitiveDigis.max_quality_to_overwrite_t0 = 9 # strict inequality
+#process.dtTriggerPhase2PrimitiveDigis.phi_window = 50
+#process.dtTriggerPhase2PrimitiveDigis.storeAllRPCHits = False
 
 process.source = cms.Source("PoolSource",fileNames = cms.untracked.vstring(
-        #'file:/eos/user/c/carrillo/digis_segments_Run2016BSingleMuonRAW-RECO.root'
         'file:/eos/cms/store/group/dpg_dt/comm_dt/TriggerSimulation/SamplesReco/SingleMu_FlatPt-2to100/Version_10_5_0/SimRECO_1.root'
         #'file:/eos/cms/store/group/dpg_rpc/comm_rpc/UpgradePhaseII/RPC_PLUS_DT/SingleMu_FlatPt-2to100_10_5_0_MaryCruz_WithRPCRecHits/SimRECO_1.root'
         )
@@ -53,7 +54,7 @@ process.maxEvents = cms.untracked.PSet(
 
 process.out = cms.OutputModule("PoolOutputModule",
                                outputCommands = cms.untracked.vstring('keep *'),
-                               fileName = cms.untracked.string('DTTriggerPhase2Primitives100_withRPC_StoreAllRpcHits.root')
+                               fileName = cms.untracked.string('DTTriggerPhase2Primitives100_withRPC.root')
 )
 
 process.p = cms.Path(process.rpcRecHits*process.CalibratedDigis*process.dtTriggerPhase2PrimitiveDigis)

--- a/L1Trigger/DTPhase2Trigger/test/primitivesPhase2Prod_over_dTDigis_and_4Dsegments_cfg_withRPC.py
+++ b/L1Trigger/DTPhase2Trigger/test/primitivesPhase2Prod_over_dTDigis_and_4Dsegments_cfg_withRPC.py
@@ -37,6 +37,7 @@ process.load('Configuration.Geometry.GeometryExtended2023D38Reco_cff')
 process.load('Configuration.Geometry.GeometryExtended2023D38_cff')
 process.dtTriggerPhase2PrimitiveDigis.useRPC = True
 process.dtTriggerPhase2PrimitiveDigis.max_quality_to_overwrite_t0 = 9 # strict inequality
+#process.dtTriggerPhase2PrimitiveDigis.storeAllRPCHits = True
 process.dtTriggerPhase2PrimitiveDigis.scenario = 0 # 0 for mc, 1 for data, 2 for slice test
 
 process.source = cms.Source("PoolSource",fileNames = cms.untracked.vstring(
@@ -46,12 +47,12 @@ process.source = cms.Source("PoolSource",fileNames = cms.untracked.vstring(
         )
                             )
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(5000)
+    input = cms.untracked.int32(100)
 )
 
 process.out = cms.OutputModule("PoolOutputModule",
                                outputCommands = cms.untracked.vstring('keep *'),
-                               fileName = cms.untracked.string('DTTriggerPhase2Primitives5000_withRPC.root')
+                               fileName = cms.untracked.string('DTTriggerPhase2Primitives100_withRPC.root')
 )
 
 process.p = cms.Path(process.rpcRecHits*process.CalibratedDigis*process.dtTriggerPhase2PrimitiveDigis)

--- a/L1Trigger/DTPhase2Trigger/test/primitivesPhase2Prod_over_dTDigis_and_4Dsegments_cfg_withRPC.py
+++ b/L1Trigger/DTPhase2Trigger/test/primitivesPhase2Prod_over_dTDigis_and_4Dsegments_cfg_withRPC.py
@@ -36,8 +36,9 @@ process.rpcRecHits.rpcDigiLabel = cms.InputTag('simMuonRPCDigis')
 process.load('Configuration.Geometry.GeometryExtended2023D38Reco_cff')
 process.load('Configuration.Geometry.GeometryExtended2023D38_cff')
 process.dtTriggerPhase2PrimitiveDigis.useRPC = True
+process.dtTriggerPhase2PrimitiveDigis.bx_window = 50 # TO BE modified when DT and RPC will have same BX definition...
 process.dtTriggerPhase2PrimitiveDigis.max_quality_to_overwrite_t0 = 9 # strict inequality
-#process.dtTriggerPhase2PrimitiveDigis.storeAllRPCHits = True
+process.dtTriggerPhase2PrimitiveDigis.storeAllRPCHits = True
 process.dtTriggerPhase2PrimitiveDigis.scenario = 0 # 0 for mc, 1 for data, 2 for slice test
 
 process.source = cms.Source("PoolSource",fileNames = cms.untracked.vstring(
@@ -52,7 +53,7 @@ process.maxEvents = cms.untracked.PSet(
 
 process.out = cms.OutputModule("PoolOutputModule",
                                outputCommands = cms.untracked.vstring('keep *'),
-                               fileName = cms.untracked.string('DTTriggerPhase2Primitives100_withRPC.root')
+                               fileName = cms.untracked.string('DTTriggerPhase2Primitives100_withRPC_StoreAllRpcHits.root')
 )
 
 process.p = cms.Path(process.rpcRecHits*process.CalibratedDigis*process.dtTriggerPhase2PrimitiveDigis)


### PR DESCRIPTION
#### PR description:

 - RPC only segments (had to refactor all the code to ease phiBending computation)
 - BX and Phi window to match RPC/DT
 - remove RPC hit matched to DT or used to build RPC only segments

#### PR validation:

https://indico.cern.ch/event/849656/contributions/3570833/attachments/1911425/3158519/20190919_RPC_DT_P2TP.pdf
