### PR TITLE
Implemented first buffering + "super-cells" version for groupings + code cleaning

### DIFF
--- a/L1Trigger/DTPhase2Trigger/interface/DTTrigPhase2Prod.h
+++ b/L1Trigger/DTPhase2Trigger/interface/DTTrigPhase2Prod.h
@@ -152,7 +152,9 @@ class DTTrigPhase2Prod: public edm::EDProducer {
     MuonPathAssociator* mpathassociator;
 
     // Buffering
-    Bool_t activateBuffer;
+    Bool_t  activateBuffer;
+    Int_t   superCellhalfspacewidth;
+    Float_t superCelltimewidth;
     std::vector<DTDigiCollection*> distribDigis(std::queue<std::pair<DTLayerId*, DTDigi*>>& inQ);
     void processDigi(std::queue<std::pair<DTLayerId*, DTDigi*>>& inQ, std::vector<std::queue<std::pair<DTLayerId*, DTDigi*>>*>& vec);
 

--- a/L1Trigger/DTPhase2Trigger/interface/DTTrigPhase2Prod.h
+++ b/L1Trigger/DTPhase2Trigger/interface/DTTrigPhase2Prod.h
@@ -5,10 +5,15 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Run.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "DataFormats/DTRecHit/interface/DTRecSegment4DCollection.h"
-#include "DataFormats/DTRecHit/interface/DTRecSegment2DCollection.h"
+
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "Geometry/DTGeometry/interface/DTGeometry.h"
+#include "Geometry/DTGeometry/interface/DTLayer.h"
+
 #include "TFile.h"
 #include "TH1F.h"
 #include "TH2F.h"
@@ -29,6 +34,12 @@
 #include "L1Trigger/DTPhase2Trigger/interface/MPQualityEnhancerFilter.h"
 #include "L1Trigger/DTPhase2Trigger/interface/MPRedundantFilter.h"
 
+#include "L1Trigger/DTSectorCollector/interface/DTSectCollPhSegm.h"
+#include "L1Trigger/DTSectorCollector/interface/DTSectCollThSegm.h"
+
+#include "L1TriggerConfig/DTTPGConfig/interface/DTConfigManagerRcd.h"
+#include "L1TriggerConfig/DTTPGConfig/interface/DTConfigManager.h"
+
 #include "CalibMuon/DTDigiSync/interface/DTTTrigBaseSync.h"
 #include "CalibMuon/DTDigiSync/interface/DTTTrigSyncFactory.h"
 
@@ -37,7 +48,12 @@
 #include "DataFormats/MuonDetId/interface/DTLayerId.h"
 #include "DataFormats/MuonDetId/interface/DTWireId.h"
 #include "DataFormats/DTDigi/interface/DTDigiCollection.h"
+#include "DataFormats/DTRecHit/interface/DTRecSegment4DCollection.h"
+#include "DataFormats/DTRecHit/interface/DTRecSegment2DCollection.h"
+#include "DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTPhContainer.h"
+#include "DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTPhDigi.h"
 
+// DT trigger GeomUtils
 #include "DQM/DTMonitorModule/interface/DTTrigGeomUtils.h"
 
 //RPC TP
@@ -48,18 +64,20 @@
 
 
 #include <fstream>
+#include <iostream>
+#include <queue>
+#include <cmath>
 
 
-class DTTrigPhase2Prod: public edm::EDProducer{
-  
-    typedef std::map< DTChamberId,DTDigiCollection,std::less<DTChamberId> > DTDigiMap;
-    typedef DTDigiMap::iterator DTDigiMap_iterator;
-    typedef DTDigiMap::const_iterator DTDigiMap_const_iterator;
+class DTTrigPhase2Prod: public edm::EDProducer {
+  typedef std::map< DTChamberId,DTDigiCollection,std::less<DTChamberId> > DTDigiMap;
+  typedef DTDigiMap::iterator DTDigiMap_iterator;
+  typedef DTDigiMap::const_iterator DTDigiMap_const_iterator;
 
- public:
+  public:
     //! Constructor
     DTTrigPhase2Prod(const edm::ParameterSet& pset);
-   
+
     //! Destructor
     ~DTTrigPhase2Prod() override;
     
@@ -70,8 +88,8 @@ class DTTrigPhase2Prod: public edm::EDProducer{
     //! Producer: process every event and generates trigger data
     void produce(edm::Event & iEvent, const edm::EventSetup& iEventSetup) override;
     
-//! endRun: finish things
-void endRun(edm::Run const& iRun, const edm::EventSetup& iEventSetup) override;
+    //! endRun: finish things
+    void endRun(edm::Run const& iRun, const edm::EventSetup& iEventSetup) override;
     
     edm::ESHandle<DTGeometry> dtGeo;
 
@@ -101,7 +119,7 @@ void endRun(edm::Run const& iRun, const edm::EventSetup& iEventSetup) override;
 
     DTTrigGeomUtils *trigGeomUtils;
 
- private:
+  private:
     // Trigger Configuration Manager CCB validity flag
     bool my_CCBValid;
 
@@ -124,14 +142,19 @@ void endRun(edm::Run const& iRun, const edm::EventSetup& iEventSetup) override;
     edm::EDGetTokenT<DTRecSegment4DCollection> dt4DSegmentsToken;
     edm::EDGetTokenT<DTDigiCollection> dtDigisToken;
     edm::EDGetTokenT<RPCRecHitCollection> rpcRecHitsLabel;
-               
+
     // Grouping attributes and methods
     Int_t grcode; // Grouping code
     MotherGrouping* grouping_obj;
     MuonPathAnalyzer* mpathanalyzer;
-    MPFilter*   mpathqualityenhancer;
-    MPFilter*   mpathredundantfilter;
+    MPFilter* mpathqualityenhancer;
+    MPFilter* mpathredundantfilter;
     MuonPathAssociator* mpathassociator;
+
+    // Buffering
+    Bool_t activateBuffer;
+    std::vector<DTDigiCollection*> distribDigis(std::queue<std::pair<DTLayerId*, DTDigi*>>& inQ);
+    void processDigi(std::queue<std::pair<DTLayerId*, DTDigi*>>& inQ, std::vector<std::queue<std::pair<DTLayerId*, DTDigi*>>*>& vec);
 
     // RPC
     RPCIntegrator* rpc_integrator;
@@ -144,4 +167,3 @@ void endRun(edm::Run const& iRun, const edm::EventSetup& iEventSetup) override;
 
 
 #endif
-

--- a/L1Trigger/DTPhase2Trigger/interface/HoughGrouping.h
+++ b/L1Trigger/DTPhase2Trigger/interface/HoughGrouping.h
@@ -101,29 +101,6 @@ using namespace edm;
 using namespace cms;
 
 
-struct {
-  Bool_t operator()(std::tuple<UShort_t, Bool_t*, Bool_t*, UShort_t, Double_t*, DTPrimitive*> a, std::tuple<UShort_t, Bool_t*, Bool_t*, UShort_t, Double_t*, DTPrimitive*> b) const {
-    
-    UShort_t sumhqa    = 0; UShort_t sumhqb    = 0;
-    UShort_t sumlqa    = 0; UShort_t sumlqb    = 0;
-    Double_t sumdista  = 0; Double_t sumdistb  = 0;
-    
-    for (UShort_t lay = 0; lay < 8; lay++) {
-      sumhqa   += (UShort_t)get<1>(a)[lay]; sumhqb   += (UShort_t)get<1>(b)[lay];
-      sumlqa   += (UShort_t)get<2>(a)[lay]; sumlqb   += (UShort_t)get<2>(b)[lay];
-      sumdista += get<4>(a)[lay];           sumdistb += get<4>(b)[lay];
-    }
-    
-    if      (get<0>(a) != get<0>(b)) return (get<0>(a) > get<0>(b)); // number of layers with hits
-    else if (sumhqa    != sumhqb)    return (sumhqa    > sumhqb);    // number of hq hits
-    else if (sumlqa    != sumlqb)    return (sumlqa    > sumlqb);    // number of lq hits
-    else if (get<3>(a) != get<3>(b)) return (get<3>(a) < get<3>(b)); // abs. diff. between SL1 & SL3 hits
-    else                             return (sumdista < sumdistb);   // abs. dist. to digis
-  }
-} HoughOrdering;
-
-
-
 // ===============================================================================
 // Class declarations
 // ===============================================================================

--- a/L1Trigger/DTPhase2Trigger/python/dtTriggerPhase2PrimitiveDigis_cfi.py
+++ b/L1Trigger/DTPhase2Trigger/python/dtTriggerPhase2PrimitiveDigis_cfi.py
@@ -15,11 +15,11 @@ dtTriggerPhase2PrimitiveDigis = cms.EDProducer("DTTrigPhase2Prod",
                                                dT0_correlate_TP = cms.untracked.double(25.), 
                                                dBX_correlate_TP = cms.untracked.int32(0), 
                                                dTanPsi_correlate_TP = cms.untracked.double(99999.),
-					       clean_chi2_correlation = cms.untracked.bool(True),
+                                               clean_chi2_correlation = cms.untracked.bool(True),
                                                allow_confirmation = cms.untracked.bool(True),
-					       use_LSB = cms.untracked.bool(True),
-					       tanPsi_precision = cms.untracked.double(1./4096.),
-					       x_precision = cms.untracked.double(0.004),
+                                               use_LSB = cms.untracked.bool(True),
+                                               tanPsi_precision = cms.untracked.double(1./4096.),
+                                               x_precision = cms.untracked.double(0.004),
                                                minx_match_2digis = cms.untracked.double(1.),
                                                p2_df = cms.untracked.int32(2), #0 for phase-1, 1 for slice-test, 2 for phase-2 carlo-federica
                                                scenario = cms.untracked.int32(0), #0 for mc, 1 for data, 2 for slice test
@@ -42,7 +42,8 @@ dtTriggerPhase2PrimitiveDigis = cms.EDProducer("DTTrigPhase2Prod",
                                                bx_window = cms.untracked.int32(1), # will look for RPC cluster within a bunch crossing window of 'dt.BX +- bx_window' 
                                                phi_window = cms.untracked.double(50.), # will look for RPC cluster within a phi window of +- phi_window in arbitrary coordinates (plot the value we cut on in RPCIntergator to fine tune it)
                                                max_quality_to_overwrite_t0 = cms.untracked.int32(9), # will use RPC  to set 't0' for TP with quality < 'max_quality_to_overwrite_t0'
-                                               storeAllRPCHits = cms.untracked.bool(False)
+                                               storeAllRPCHits = cms.untracked.bool(False),
+                                               activateBuffer  = cms.untracked.bool(False),
                                                )
 
 dtTriggerPhase2PrimitiveDigis.HoughGrouping      = HoughGrouping

--- a/L1Trigger/DTPhase2Trigger/python/dtTriggerPhase2PrimitiveDigis_cfi.py
+++ b/L1Trigger/DTPhase2Trigger/python/dtTriggerPhase2PrimitiveDigis_cfi.py
@@ -44,6 +44,8 @@ dtTriggerPhase2PrimitiveDigis = cms.EDProducer("DTTrigPhase2Prod",
                                                max_quality_to_overwrite_t0 = cms.untracked.int32(9), # will use RPC  to set 't0' for TP with quality < 'max_quality_to_overwrite_t0'
                                                storeAllRPCHits = cms.untracked.bool(False),
                                                activateBuffer  = cms.untracked.bool(False),
+                                               superCelltimewidth = cms.untracked.double(400), # in nanoseconds
+                                               superCellspacewidth = cms.untracked.int32(20), # in number of cells: IT MUST BE AN EVEN NUMBER
                                                )
 
 dtTriggerPhase2PrimitiveDigis.HoughGrouping      = HoughGrouping

--- a/L1Trigger/DTPhase2Trigger/src/DTTrigPhase2Prod.cc
+++ b/L1Trigger/DTPhase2Trigger/src/DTTrigPhase2Prod.cc
@@ -88,7 +88,9 @@ DTTrigPhase2Prod::DTTrigPhase2Prod(const ParameterSet& pset) {
   }
 
   // Getting buffer option
-  activateBuffer = pset.getUntrackedParameter<Bool_t>("activateBuffer");
+  activateBuffer          = pset.getUntrackedParameter<Bool_t>("activateBuffer");
+  superCellhalfspacewidth = pset.getUntrackedParameter<Int_t>("superCellspacewidth")/2;
+  superCelltimewidth      = pset.getUntrackedParameter<Double_t>("superCelltimewidth");
 
   mpathqualityenhancer = new MPQualityEnhancerFilter(pset);
   mpathredundantfilter = new MPRedundantFilter(pset);
@@ -625,14 +627,10 @@ std::vector<DTDigiCollection*> DTTrigPhase2Prod::distribDigis(std::queue<std::pa
 void DTTrigPhase2Prod::processDigi(std::queue<std::pair<DTLayerId*, DTDigi*>>& inQ, std::vector<std::queue<std::pair<DTLayerId*, DTDigi*>>*>& vec) {
   Bool_t classified = false;
   if (vec.size() != 0) {
-//     cout << "El tamaño del vector no es nulo. En particular, es: " << vec.size() << ". Comenzando for sobre las distintas colas" << endl;
-    for (auto & sC : vec) { // Conditions for entering a super cell. TODO: add geometric requirements.
-//       cout << "comprobando uno de los elementos. Tiempo + 400: " << sC->front().second->time() + 400 << ", tiempo del otro: " << inQ.front().second->time() << endl;
-      if ((sC->front().second->time() + 400) > inQ.front().second->time()) { // Time requirement
-        if (TMath::Abs(sC->front().second->wire() - inQ.front().second->wire()) <= 10) { // Spatial requirement
-//           cout << "¡aceptado! Tamaño antes de la cola central: " << inQ.size() << " tamaño antes de la cola donde se meterá: " << sC->size() << endl;
+    for (auto & sC : vec) { // Conditions for entering a super cell.
+      if ((sC->front().second->time() + superCelltimewidth) > inQ.front().second->time()) { // Time requirement
+        if (TMath::Abs(sC->front().second->wire() - inQ.front().second->wire()) <= superCellhalfspacewidth) { // Spatial requirement
           sC->push(std::move(inQ.front()));
-//           cout << "¡aceptado! Tamaño luego de la cola central: " << inQ.size() << " tamaño luego de la cola donde se meterá: " << sC->size() << endl;
           classified = true;
         }
       }

--- a/L1Trigger/DTPhase2Trigger/src/DTTrigPhase2Prod.cc
+++ b/L1Trigger/DTPhase2Trigger/src/DTTrigPhase2Prod.cc
@@ -1,39 +1,18 @@
 #include "L1Trigger/DTPhase2Trigger/interface/DTTrigPhase2Prod.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/Run.h"
-#include "L1TriggerConfig/DTTPGConfig/interface/DTConfigManager.h"
-
-#include "L1TriggerConfig/DTTPGConfig/interface/DTConfigManagerRcd.h"
-#include "L1Trigger/DTSectorCollector/interface/DTSectCollPhSegm.h"
-#include "L1Trigger/DTSectorCollector/interface/DTSectCollThSegm.h"
-#include "DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTPhContainer.h"
-#include "DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTPhDigi.h"
-
-#include <Geometry/Records/interface/MuonGeometryRecord.h>
-#include <Geometry/DTGeometry/interface/DTGeometry.h>
-#include "Geometry/DTGeometry/interface/DTLayer.h"
-#include "DataFormats/MuonDetId/interface/DTWireId.h"
-
-
-// DT trigger GeomUtils
-#include "DQM/DTMonitorModule/interface/DTTrigGeomUtils.h"
-
-#include "CalibMuon/DTDigiSync/interface/DTTTrigBaseSync.h"
-#include "CalibMuon/DTDigiSync/interface/DTTTrigSyncFactory.h"
-
-#include <iostream>
-#include <cmath>
-
-#include "L1Trigger/DTPhase2Trigger/interface/muonpath.h"
 
 using namespace edm;
 using namespace std;
 
-typedef vector<DTSectCollPhSegm>  SectCollPhiColl;
-typedef SectCollPhiColl::const_iterator SectCollPhiColl_iterator;
-typedef vector<DTSectCollThSegm>  SectCollThetaColl;
+typedef vector<DTSectCollPhSegm>          SectCollPhiColl;
+typedef SectCollPhiColl::const_iterator   SectCollPhiColl_iterator;
+typedef vector<DTSectCollThSegm>          SectCollThetaColl;
 typedef SectCollThetaColl::const_iterator SectCollThetaColl_iterator;
+
+struct {
+  Bool_t operator()(std::pair<DTLayerId*, DTDigi*> a, std::pair<DTLayerId*, DTDigi*> b) const {
+    return (a.second->time() < b.second->time());
+  }
+} DigiTimeOrdering;
 
 /*
   Channels are labeled following next schema:
@@ -62,65 +41,63 @@ typedef SectCollThetaColl::const_iterator SectCollThetaColl_iterator;
 // };
 
 
-DTTrigPhase2Prod::DTTrigPhase2Prod(const ParameterSet& pset){
-    
-    produces<L1Phase2MuDTPhContainer>();
-    
-    debug = pset.getUntrackedParameter<bool>("debug");
-    dump = pset.getUntrackedParameter<bool>("dump");
-    min_phinhits_match_segment = pset.getUntrackedParameter<int>("min_phinhits_match_segment");
+DTTrigPhase2Prod::DTTrigPhase2Prod(const ParameterSet& pset) {
+  produces<L1Phase2MuDTPhContainer>();
 
-    do_correlation = pset.getUntrackedParameter<bool>("do_correlation");
-    p2_df = pset.getUntrackedParameter<int>("p2_df");
-    
-    scenario = pset.getUntrackedParameter<int>("scenario");
-    
-    txt_ttrig_bc0 = pset.getUntrackedParameter<bool>("apply_txt_ttrig_bc0");
-    
-    dtDigisToken = consumes< DTDigiCollection >(pset.getParameter<edm::InputTag>("digiTag"));
+  debug = pset.getUntrackedParameter<bool>("debug");
+  dump = pset.getUntrackedParameter<bool>("dump");
+  min_phinhits_match_segment = pset.getUntrackedParameter<int>("min_phinhits_match_segment");
 
-    rpcRecHitsLabel = consumes<RPCRecHitCollection>(pset.getUntrackedParameter < edm::InputTag > ("rpcRecHits"));
-    useRPC = pset.getUntrackedParameter<bool>("useRPC");
-  
+  do_correlation = pset.getUntrackedParameter<bool>("do_correlation");
+  p2_df = pset.getUntrackedParameter<int>("p2_df");
+
+  scenario = pset.getUntrackedParameter<int>("scenario");
+
+  txt_ttrig_bc0 = pset.getUntrackedParameter<bool>("apply_txt_ttrig_bc0");
+
+  dtDigisToken = consumes< DTDigiCollection >(pset.getParameter<edm::InputTag>("digiTag"));
+
+  rpcRecHitsLabel = consumes<RPCRecHitCollection>(pset.getUntrackedParameter < edm::InputTag > ("rpcRecHits"));
+  useRPC = pset.getUntrackedParameter<bool>("useRPC");
 
 
+  // Choosing grouping scheme:
+  grcode = pset.getUntrackedParameter<int>("grouping_code");
 
-    
-    // Choosing grouping scheme:
-    grcode = pset.getUntrackedParameter<int>("grouping_code");
-    
-    if      (grcode == 0) grouping_obj = new InitialGrouping(pset);
-    else if (grcode == 1) grouping_obj = new HoughGrouping(pset.getParameter<edm::ParameterSet>("HoughGrouping"));
-    else if (grcode == 2) grouping_obj = new PseudoBayesGrouping(pset.getParameter<edm::ParameterSet>("PseudoBayesPattern"));
-    else {
+  if      (grcode == 0) grouping_obj = new InitialGrouping(pset);
+  else if (grcode == 1) grouping_obj = new HoughGrouping(pset.getParameter<edm::ParameterSet>("HoughGrouping"));
+  else if (grcode == 2) grouping_obj = new PseudoBayesGrouping(pset.getParameter<edm::ParameterSet>("PseudoBayesPattern"));
+  else {
+    if (debug) cout << "DTp2::constructor: Non-valid grouping code. Choosing InitialGrouping by default." << endl;
+    grouping_obj = new InitialGrouping(pset);
+  }
 
-        if (debug) cout << "DTp2::constructor: Non-valid grouping code. Choosing InitialGrouping by default." << endl;
-        grouping_obj = new InitialGrouping(pset);
-    }
-    
-    if (grcode==0) {   
-      if (debug) cout << "DTp2:constructor: JM analyzer" << endl;
-      mpathanalyzer        = new MuonPathAnalyzerPerSL(pset);
-    } else {
-      cout << "++++++++++++++++++++++++++++++++++++++++++++++" <<endl;
-      cout << "               WARNING!!!!!                   " <<endl;
-      cout << "++++++++++++++++++++++++++++++++++++++++++++++" <<endl;
-      cout << " This grouping option is not fully supported  " <<endl;
-      cout << " yet.                                         " <<endl;
-      cout << " USE IT AT YOUR OWN RISK!                     " <<endl;
-      cout << "++++++++++++++++++++++++++++++++++++++++++++++" <<endl;      
-      if (debug) cout << "DTp2:constructor: Full chamber analyzer" << endl;  
-      mpathanalyzer        = new MuonPathAnalyzerInChamber(pset);      
-    } 
-    
-    mpathqualityenhancer = new MPQualityEnhancerFilter(pset);
-    mpathredundantfilter = new MPRedundantFilter(pset);
-    mpathassociator      = new MuonPathAssociator(pset);
-    rpc_integrator       = new RPCIntegrator(pset);
+  if (grcode==0) {
+    if (debug) cout << "DTp2:constructor: JM analyzer" << endl;
+    mpathanalyzer        = new MuonPathAnalyzerPerSL(pset);
+  } else {
+    cout << "++++++++++++++++++++++++++++++++++++++++++++++" <<endl;
+    cout << "               WARNING!!!!!                   " <<endl;
+    cout << "++++++++++++++++++++++++++++++++++++++++++++++" <<endl;
+    cout << " This grouping option is not fully supported  " <<endl;
+    cout << " yet.                                         " <<endl;
+    cout << " USE IT AT YOUR OWN RISK!                     " <<endl;
+    cout << "++++++++++++++++++++++++++++++++++++++++++++++" <<endl;
+    if (debug) cout << "DTp2:constructor: Full chamber analyzer" << endl;
+    mpathanalyzer        = new MuonPathAnalyzerInChamber(pset);
+  }
+
+  // Getting buffer option
+  activateBuffer = pset.getUntrackedParameter<Bool_t>("activateBuffer");
+
+  mpathqualityenhancer = new MPQualityEnhancerFilter(pset);
+  mpathredundantfilter = new MPRedundantFilter(pset);
+  mpathassociator      = new MuonPathAssociator(pset);
+  rpc_integrator       = new RPCIntegrator(pset);
 }
 
-DTTrigPhase2Prod::~DTTrigPhase2Prod(){
 
+DTTrigPhase2Prod::~DTTrigPhase2Prod(){
   //delete inMuonPath;
   //delete outValidMuonPath;
   
@@ -151,130 +128,169 @@ void DTTrigPhase2Prod::beginRun(edm::Run const& iRun, const edm::EventSetup& iEv
   mpathredundantfilter->initialise(iEventSetup); // Filter object initialisation
   mpathassociator->initialise(iEventSetup); // Associator object initialisation
   
-    //trigGeomUtils = new DTTrigGeomUtils(dtGeo);
+  //trigGeomUtils = new DTTrigGeomUtils(dtGeo);
 
-    //filling up zcn
-    for (int ist=0; ist<4; ++ist) {
-	const DTChamberId chId(-2,ist+1,4);
-	const DTChamber *chamb = dtGeo->chamber(chId);
-	const DTSuperLayer *sl1 = chamb->superLayer(DTSuperLayerId(chId,1));
-	const DTSuperLayer *sl3 = chamb->superLayer(DTSuperLayerId(chId,3));
-	zcn[ist] = .5*(chamb->surface().toLocal(sl1->position()).z() + chamb->surface().toLocal(sl3->position()).z());
-    }
+  //filling up zcn
+  for (int ist=0; ist<4; ++ist) {
+    const DTChamberId chId(-2,ist+1,4);
+    const DTChamber *chamb = dtGeo->chamber(chId);
+    const DTSuperLayer *sl1 = chamb->superLayer(DTSuperLayerId(chId,1));
+    const DTSuperLayer *sl3 = chamb->superLayer(DTSuperLayerId(chId,3));
+    zcn[ist] = .5*(chamb->surface().toLocal(sl1->position()).z() + chamb->surface().toLocal(sl3->position()).z());
+  }
 
-    const DTChamber* chamb   = dtGeo->chamber(DTChamberId(-2,4,13));
-    const DTChamber* scchamb = dtGeo->chamber(DTChamberId(-2,4,4));
-    xCenter[0] = scchamb->toLocal(chamb->position()).x()*.5;
-    chamb   = dtGeo->chamber(DTChamberId(-2,4,14));
-    scchamb = dtGeo->chamber(DTChamberId(-2,4,10));
-    xCenter[1] = scchamb->toLocal(chamb->position()).x()*.5;
+  const DTChamber* chamb   = dtGeo->chamber(DTChamberId(-2,4,13));
+  const DTChamber* scchamb = dtGeo->chamber(DTChamberId(-2,4,4));
+  xCenter[0] = scchamb->toLocal(chamb->position()).x()*.5;
+  chamb   = dtGeo->chamber(DTChamberId(-2,4,14));
+  scchamb = dtGeo->chamber(DTChamberId(-2,4,10));
+  xCenter[1] = scchamb->toLocal(chamb->position()).x()*.5;
 }
 
 
 void DTTrigPhase2Prod::produce(Event & iEvent, const EventSetup& iEventSetup){
-    if(debug) cout << "DTTrigPhase2Prod::produce " << endl;
-    edm::Handle<DTDigiCollection> dtdigis;
-    iEvent.getByToken(dtDigisToken, dtdigis);
-    
-    if(debug) std::cout <<"\t Getting the RPC RecHits"<<std::endl;
-    edm::Handle<RPCRecHitCollection> rpcRecHits;
-    iEvent.getByToken(rpcRecHitsLabel,rpcRecHits);
-    
-    ///////////////////////////////////
-    // GROUPING CODE: 
-    ////////////////////////////////
-    DTDigiMap digiMap;
-    DTDigiCollection::DigiRangeIterator detUnitIt;
-    for (detUnitIt=dtdigis->begin(); detUnitIt!=dtdigis->end(); ++detUnitIt) {
-	const DTLayerId& layId               = (*detUnitIt).first;
-	const DTChamberId chambId            = layId.superlayerId().chamberId();
-	const DTDigiCollection::Range& range = (*detUnitIt).second; 
-	digiMap[chambId].put(range,layId);
-    }
+  if(debug) cout << "DTTrigPhase2Prod::produce" << endl;
+  edm::Handle<DTDigiCollection> dtdigis;
+  iEvent.getByToken(dtDigisToken, dtdigis);
 
-    // generate a list muon paths for each event!!!
-    std::vector<MuonPath*> muonpaths;
-    for (std::vector<const DTChamber*>::const_iterator ich = dtGeo->chambers().begin(); ich != dtGeo->chambers().end(); ich++) {
-        const DTChamber* chamb  = (*ich);
-        DTChamberId chid        = chamb->id();
-        DTDigiMap_iterator dmit = digiMap.find(chid);
-        
-        if (dmit !=digiMap.end()) grouping_obj->run(iEvent, iEventSetup, (*dmit).second, &muonpaths);
-    }   
-    digiMap.clear();
-    
-    
-    if (dump) {
-      for (unsigned int i=0; i<muonpaths.size(); i++){
-	cout << iEvent.id().event() << "      mpath " << i << ": ";
-	for (int lay=0; lay<muonpaths.at(i)->getNPrimitives(); lay++)
-	  cout << muonpaths.at(i)->getPrimitive(lay)->getChannelId() << " ";
-	for (int lay=0; lay<muonpaths.at(i)->getNPrimitives(); lay++)
-	  cout << muonpaths.at(i)->getPrimitive(lay)->getTDCTime() << " ";
-	for (int lay=0; lay<muonpaths.at(i)->getNPrimitives(); lay++)
-	  cout << muonpaths.at(i)->getPrimitive(lay)->getLaterality() << " ";
-	cout << endl;	
+  if(debug) std::cout <<"\t Getting the RPC RecHits"<<std::endl;
+  edm::Handle<RPCRecHitCollection> rpcRecHits;
+  iEvent.getByToken(rpcRecHitsLabel,rpcRecHits);
+
+  ////////////////////////////////
+  // GROUPING CODE:
+  ////////////////////////////////
+  DTDigiMap digiMap;
+  DTDigiCollection::DigiRangeIterator detUnitIt;
+  for (detUnitIt=dtdigis->begin(); detUnitIt!=dtdigis->end(); ++detUnitIt) {
+    const DTLayerId& layId               = (*detUnitIt).first;
+    const DTChamberId chambId            = layId.superlayerId().chamberId();
+    const DTDigiCollection::Range& range = (*detUnitIt).second;
+    digiMap[chambId].put(range,layId);
+  }
+
+  // generate a list muon paths for each event!!!
+  if (debug && activateBuffer) cout << "DTTrigPhase2Prod::produce - Getting and grouping digis per chamber using a buffer and super cells." << endl;
+  else if (debug)              cout << "DTTrigPhase2Prod::produce - Getting and grouping digis per chamber." << endl;
+  std::vector<MuonPath*> muonpaths;
+  for (std::vector<const DTChamber*>::const_iterator ich = dtGeo->chambers().begin(); ich != dtGeo->chambers().end(); ich++) {
+    // The code inside this for loop would ideally later fit inside a trigger unit (in principle, a DT station) of the future Phase 2 DT Trigger.
+    const DTChamber* chamb  = (*ich);
+    DTChamberId chid        = chamb->id();
+    DTDigiMap_iterator dmit = digiMap.find(chid);
+
+    if (dmit == digiMap.end()) continue;
+
+    if (activateBuffer) { // Use buffering (per chamber) or not
+      // Import digis from the station
+      std::vector<std::pair<DTLayerId*, DTDigi*>> tmpvec; tmpvec.clear();
+
+      for (DTDigiCollection::DigiRangeIterator dtLayerIdIt = (*dmit).second.begin();   dtLayerIdIt != (*dmit).second.end();      dtLayerIdIt++) {
+        for (DTDigiCollection::const_iterator  digiIt = ((*dtLayerIdIt).second).first; digiIt != ((*dtLayerIdIt).second).second; digiIt++) {
+          DTLayerId* tmplayer = new DTLayerId((*dtLayerIdIt).first);
+          DTDigi*    tmpdigi  = new DTDigi((*digiIt));
+          tmpvec.push_back({tmplayer, tmpdigi});
+        }
       }
+
+      // Check to enhance CPU time usage
+      if (tmpvec.size() == 0) continue;
+
+      // Order digis depending on TDC time and insert them into a queue (FIFO buffer). TODO: adapt for MC simulations.
+      std::sort(tmpvec.begin(), tmpvec.end(), DigiTimeOrdering);
+      std::queue<std::pair<DTLayerId*, DTDigi*>> timequeue;
+
+      for (auto &elem : tmpvec) timequeue.push(std::move(elem));
+      tmpvec.clear();
+
+      // Distribute the digis from the queue into supercells
+      std::vector<DTDigiCollection*> superCells;
+      superCells = distribDigis(timequeue);
+
+      // Process each supercell & collect the resulting muonpaths (as the muonpaths std::vector is only enlarged each time
+      // the groupings access it, it's not needed to "collect" the final products).
+      while (!superCells.empty()) {
+        grouping_obj->run(iEvent, iEventSetup, *(superCells.back()), &muonpaths);
+        superCells.pop_back();
+      }
+    }
+    else {
+      grouping_obj->run(iEvent, iEventSetup, (*dmit).second, &muonpaths);
+    }
+  }
+  digiMap.clear();
+
+
+  if (dump) {
+    for (unsigned int i=0; i<muonpaths.size(); i++){
+      cout << iEvent.id().event() << "      mpath " << i << ": ";
+      for (int lay=0; lay<muonpaths.at(i)->getNPrimitives(); lay++)
+        cout << muonpaths.at(i)->getPrimitive(lay)->getChannelId() << " ";
+      for (int lay=0; lay<muonpaths.at(i)->getNPrimitives(); lay++)
+        cout << muonpaths.at(i)->getPrimitive(lay)->getTDCTime() << " ";
+      for (int lay=0; lay<muonpaths.at(i)->getNPrimitives(); lay++)
+        cout << muonpaths.at(i)->getPrimitive(lay)->getLaterality() << " ";
       cout << endl;
     }
+    cout << endl;
+  }
 
-    // FILTER GROUPING
-    std::vector<MuonPath*> filteredmuonpaths;
-    if (grcode==0) {
-      mpathredundantfilter->run(iEvent, iEventSetup, muonpaths,filteredmuonpaths);   
-    }
+  // FILTER GROUPING
+  std::vector<MuonPath*> filteredmuonpaths;
+  if (grcode==0) {
+    mpathredundantfilter->run(iEvent, iEventSetup, muonpaths,filteredmuonpaths);
+  }
     
-    if (dump) {
-      for (unsigned int i=0; i<filteredmuonpaths.size(); i++){
-	cout << iEvent.id().event() << " filt. mpath " << i << ": ";
-	for (int lay=0; lay<filteredmuonpaths.at(i)->getNPrimitives(); lay++)
-	  cout << filteredmuonpaths.at(i)->getPrimitive(lay)->getChannelId() << " ";
-	for (int lay=0; lay<filteredmuonpaths.at(i)->getNPrimitives(); lay++)
-	  cout << filteredmuonpaths.at(i)->getPrimitive(lay)->getTDCTime() << " ";
-	cout << endl;	
-      }
+  if (dump) {
+    for (unsigned int i=0; i<filteredmuonpaths.size(); i++){
+      cout << iEvent.id().event() << " filt. mpath " << i << ": ";
+      for (int lay=0; lay<filteredmuonpaths.at(i)->getNPrimitives(); lay++)
+        cout << filteredmuonpaths.at(i)->getPrimitive(lay)->getChannelId() << " ";
+      for (int lay=0; lay<filteredmuonpaths.at(i)->getNPrimitives(); lay++)
+        cout << filteredmuonpaths.at(i)->getPrimitive(lay)->getTDCTime() << " ";
       cout << endl;
     }
-    
-    
-    ///////////////////////////////////////////
-    /// FITTING SECTION; 
-    ///////////////////////////////////////////
-    if(debug) cout << "MUON PATHS found: " << muonpaths.size() << " ("<< filteredmuonpaths.size() <<") in event "<< iEvent.id().event()<<endl;
-    if(debug) std::cout<<"filling NmetaPrimtives"<<std::endl;
-    std::vector<metaPrimitive> metaPrimitives;
-    std::vector<MuonPath*> outmpaths;
-    if (grcode==0) {
-      if (debug) cout << "Fitting 1SL " << endl;      
-      mpathanalyzer->run(iEvent, iEventSetup,  filteredmuonpaths, metaPrimitives);  
-    }
-    else   {
-      // implementation for advanced (2SL) grouping, no filter required..
-      if (debug) cout << "Fitting 2SL at once " << endl;
-      mpathanalyzer->run(iEvent, iEventSetup,  muonpaths, outmpaths);   
-    }
-      
-    if (dump) {
-      for (unsigned int i=0; i<outmpaths.size(); i++){
-	cout << iEvent.id().event() << " mp " << i << ": "
-	     << outmpaths.at(i)->getBxTimeValue() << " "
-	     << outmpaths.at(i)->getHorizPos() << " "
-	     << outmpaths.at(i)->getTanPhi() << " "
-	     << outmpaths.at(i)->getPhi() << " "
-	     << outmpaths.at(i)->getPhiB() << " "
-	     << outmpaths.at(i)->getQuality() << " "
-	     << outmpaths.at(i)->getChiSq() << " "
-	     << endl;
-      }
-      for (unsigned int i=0; i<metaPrimitives.size(); i++){
-	    cout << iEvent.id().event() << " mp " << i << ": ";
-	    printmP(metaPrimitives.at(i));
-	    cout<<endl;
-	}
-    }
+    cout << endl;
+  }
 
-    
-    if(debug) std::cout<<"deleting muonpaths"<<std::endl;
+  ///////////////////////////////////////////
+  /// FITTING SECTION;
+  ///////////////////////////////////////////
+  if(debug) cout << "MUON PATHS found: " << muonpaths.size() << " ("<< filteredmuonpaths.size() <<") in event "<< iEvent.id().event()<<endl;
+  if(debug) std::cout<<"filling NmetaPrimtives"<<std::endl;
+  std::vector<metaPrimitive> metaPrimitives;
+  std::vector<MuonPath*> outmpaths;
+  if (grcode==0) {
+    if (debug) cout << "Fitting 1SL " << endl;
+    mpathanalyzer->run(iEvent, iEventSetup,  filteredmuonpaths, metaPrimitives);
+  }
+  else   {
+    // implementation for advanced (2SL) grouping, no filter required..
+    if (debug) cout << "Fitting 2SL at once " << endl;
+    mpathanalyzer->run(iEvent, iEventSetup,  muonpaths, outmpaths);
+  }
+
+  if (dump) {
+    for (unsigned int i=0; i<outmpaths.size(); i++){
+      cout << iEvent.id().event() << " mp " << i << ": "
+      << outmpaths.at(i)->getBxTimeValue() << " "
+      << outmpaths.at(i)->getHorizPos() << " "
+      << outmpaths.at(i)->getTanPhi() << " "
+      << outmpaths.at(i)->getPhi() << " "
+      << outmpaths.at(i)->getPhiB() << " "
+      << outmpaths.at(i)->getQuality() << " "
+      << outmpaths.at(i)->getChiSq() << " "
+      << endl;
+      }
+    for (unsigned int i=0; i<metaPrimitives.size(); i++){
+      cout << iEvent.id().event() << " mp " << i << ": ";
+      printmP(metaPrimitives.at(i));
+      cout<<endl;
+    }
+  }
+
+
+  if(debug) std::cout<<"deleting muonpaths"<<std::endl;
     for (unsigned int i=0; i<muonpaths.size(); i++){
       delete muonpaths[i];
     }
@@ -299,9 +315,9 @@ void DTTrigPhase2Prod::produce(Event & iEvent, const EventSetup& iEventSetup){
     
     if (dump) {
       for (unsigned int i=0; i<filteredMetaPrimitives.size(); i++){
-	  cout << iEvent.id().event() << " filtered mp " << i << ": ";
-	  printmP(filteredMetaPrimitives.at(i));
-	  cout<<endl;
+        cout << iEvent.id().event() << " filtered mp " << i << ": ";
+        printmP(filteredMetaPrimitives.at(i));
+        cout<<endl;
       }
     }
     
@@ -315,38 +331,38 @@ void DTTrigPhase2Prod::produce(Event & iEvent, const EventSetup& iEventSetup){
     //// CORRELATION: 
     /////////////////////////////////////
     std::vector<metaPrimitive> correlatedMetaPrimitives;
-    if (grcode==0) mpathassociator->run(iEvent, iEventSetup, dtdigis, filteredMetaPrimitives, correlatedMetaPrimitives);  
+    if (grcode==0) mpathassociator->run(iEvent, iEventSetup, dtdigis, filteredMetaPrimitives, correlatedMetaPrimitives);
     else {
       //for(auto muonpath = muonpaths.begin();muonpath!=muonpaths.end();++muonpath) {
       for(auto muonpath = outmpaths.begin();muonpath!=outmpaths.end();++muonpath) {
-	correlatedMetaPrimitives.push_back(metaPrimitive({(*muonpath)->getRawId(),(double)(*muonpath)->getBxTimeValue(),
-		(*muonpath)->getHorizPos(), (*muonpath)->getTanPhi(),
-		(*muonpath)->getPhi(), 	    (*muonpath)->getPhiB(),
-		(*muonpath)->getChiSq(),    (int)(*muonpath)->getQuality(),
-		(*muonpath)->getPrimitive(0)->getChannelId(), (*muonpath)->getPrimitive(0)->getTDCTime(), (*muonpath)->getPrimitive(0)->getLaterality(),
-		(*muonpath)->getPrimitive(1)->getChannelId(), (*muonpath)->getPrimitive(1)->getTDCTime(), (*muonpath)->getPrimitive(1)->getLaterality(),
-		(*muonpath)->getPrimitive(2)->getChannelId(), (*muonpath)->getPrimitive(2)->getTDCTime(), (*muonpath)->getPrimitive(2)->getLaterality(),
-		(*muonpath)->getPrimitive(3)->getChannelId(), (*muonpath)->getPrimitive(3)->getTDCTime(), (*muonpath)->getPrimitive(3)->getLaterality(),
-		(*muonpath)->getPrimitive(4)->getChannelId(), (*muonpath)->getPrimitive(4)->getTDCTime(), (*muonpath)->getPrimitive(4)->getLaterality(),
-		(*muonpath)->getPrimitive(5)->getChannelId(), (*muonpath)->getPrimitive(5)->getTDCTime(), (*muonpath)->getPrimitive(5)->getLaterality(),
-		(*muonpath)->getPrimitive(6)->getChannelId(), (*muonpath)->getPrimitive(6)->getTDCTime(), (*muonpath)->getPrimitive(6)->getLaterality(),
-		(*muonpath)->getPrimitive(7)->getChannelId(), (*muonpath)->getPrimitive(7)->getTDCTime(), (*muonpath)->getPrimitive(7)->getLaterality(),
-		}));
+        correlatedMetaPrimitives.push_back(metaPrimitive({(*muonpath)->getRawId(),(double)(*muonpath)->getBxTimeValue(),
+          (*muonpath)->getHorizPos(), (*muonpath)->getTanPhi(),
+          (*muonpath)->getPhi(), 	    (*muonpath)->getPhiB(),
+          (*muonpath)->getChiSq(),    (int)(*muonpath)->getQuality(),
+          (*muonpath)->getPrimitive(0)->getChannelId(), (*muonpath)->getPrimitive(0)->getTDCTime(), (*muonpath)->getPrimitive(0)->getLaterality(),
+          (*muonpath)->getPrimitive(1)->getChannelId(), (*muonpath)->getPrimitive(1)->getTDCTime(), (*muonpath)->getPrimitive(1)->getLaterality(),
+          (*muonpath)->getPrimitive(2)->getChannelId(), (*muonpath)->getPrimitive(2)->getTDCTime(), (*muonpath)->getPrimitive(2)->getLaterality(),
+          (*muonpath)->getPrimitive(3)->getChannelId(), (*muonpath)->getPrimitive(3)->getTDCTime(), (*muonpath)->getPrimitive(3)->getLaterality(),
+          (*muonpath)->getPrimitive(4)->getChannelId(), (*muonpath)->getPrimitive(4)->getTDCTime(), (*muonpath)->getPrimitive(4)->getLaterality(),
+          (*muonpath)->getPrimitive(5)->getChannelId(), (*muonpath)->getPrimitive(5)->getTDCTime(), (*muonpath)->getPrimitive(5)->getLaterality(),
+          (*muonpath)->getPrimitive(6)->getChannelId(), (*muonpath)->getPrimitive(6)->getTDCTime(), (*muonpath)->getPrimitive(6)->getLaterality(),
+          (*muonpath)->getPrimitive(7)->getChannelId(), (*muonpath)->getPrimitive(7)->getTDCTime(), (*muonpath)->getPrimitive(7)->getLaterality(),
+        }));
       }
-    } 
+    }
     filteredMetaPrimitives.clear();
     filteredMetaPrimitives.erase(filteredMetaPrimitives.begin(),filteredMetaPrimitives.end());
 
     if(debug) std::cout<<"DTp2 in event:"<<iEvent.id().event()
-		       <<" we found "<<correlatedMetaPrimitives.size()
-		       <<" correlatedMetPrimitives (chamber)"<<std::endl;
+          <<" we found "<<correlatedMetaPrimitives.size()
+          <<" correlatedMetPrimitives (chamber)"<<std::endl;
     
-    if (dump) { 
+    if (dump) {
       for (unsigned int i=0; i<correlatedMetaPrimitives.size(); i++){
-	  cout << iEvent.id().event() << " correlated mp " << i << ": ";
-	  printmPC(correlatedMetaPrimitives.at(i));
-	  cout<<endl;
-      } 
+        cout << iEvent.id().event() << " correlated mp " << i << ": ";
+        printmPC(correlatedMetaPrimitives.at(i));
+        cout<<endl;
+      }
     }
 
     double shift_back=0;
@@ -363,13 +379,13 @@ void DTTrigPhase2Prod::produce(Event & iEvent, const EventSetup& iEventSetup){
     
     // RPC integration
     if(useRPC) {
-        if (debug) std::cout << "Start integrating RPC" << std::endl;
-        rpc_integrator->initialise(iEventSetup, shift_back);
-        rpc_integrator->prepareMetaPrimitives(rpcRecHits);
-        rpc_integrator->matchWithDTAndUseRPCTime(correlatedMetaPrimitives);
-        rpc_integrator->makeRPCOnlySegments();
-        rpc_integrator->storeRPCSingleHits();
-        rpc_integrator->removeRPCHitsUsed();
+      if (debug) std::cout << "Start integrating RPC" << std::endl;
+      rpc_integrator->initialise(iEventSetup, shift_back);
+      rpc_integrator->prepareMetaPrimitives(rpcRecHits);
+      rpc_integrator->matchWithDTAndUseRPCTime(correlatedMetaPrimitives);
+      rpc_integrator->makeRPCOnlySegments();
+      rpc_integrator->storeRPCSingleHits();
+      rpc_integrator->removeRPCHitsUsed();
     }
 
     /// STORING RESULTs 
@@ -390,33 +406,33 @@ void DTTrigPhase2Prod::produce(Event & iEvent, const EventSetup& iEventSetup){
       sectorTP=sectorTP-1;
       int sl=0;
       if((*metaPrimitiveIt).quality < 6 || (*metaPrimitiveIt).quality == 7){
-	  if(inner((*metaPrimitiveIt))) sl=1;
-	  else sl=3;
+        if(inner((*metaPrimitiveIt))) sl=1;
+        else sl=3;
       }
 
       if(p2_df==2){
-          if(debug)std::cout<<"pushing back phase-2 dataformat carlo-federica dataformat"<<std::endl;
-          outP2Ph.push_back(L1Phase2MuDTPhDigi((int)round((*metaPrimitiveIt).t0/25.)-shift_back,   // ubx (m_bx) //bx en la orbita
-                               chId.wheel(),   // uwh (m_wheel)     // FIXME: It is not clear who provides this?
-                               sectorTP,   // usc (m_sector)    // FIXME: It is not clear who provides this?
-                               chId.station(),   // ust (m_station)
-                               sl,   // ust (m_station)
-                               (int)round((*metaPrimitiveIt).phi*65536./0.8), // uphi (_phiAngle)
-                               (int)round((*metaPrimitiveIt).phiB*2048./1.4), // uphib (m_phiBending)
-                               (*metaPrimitiveIt).quality,  // uqua (m_qualityCode)
-                               (*metaPrimitiveIt).index,  // uind (m_segmentIndex)
-                               (int)round((*metaPrimitiveIt).t0)-shift_back*25,  // ut0 (m_t0Segment)
-                               (int)round((*metaPrimitiveIt).chi2*1000000),  // uchi2 (m_chi2Segment)
-                               (*metaPrimitiveIt).rpcFlag    // urpc (m_rpcFlag)
-                               ));
+        if(debug)std::cout<<"pushing back phase-2 dataformat carlo-federica dataformat"<<std::endl;
+        outP2Ph.push_back(L1Phase2MuDTPhDigi((int)round((*metaPrimitiveIt).t0/25.)-shift_back,   // ubx (m_bx) //bx en la orbita
+                              chId.wheel(),   // uwh (m_wheel)     // FIXME: It is not clear who provides this?
+                              sectorTP,   // usc (m_sector)    // FIXME: It is not clear who provides this?
+                              chId.station(),   // ust (m_station)
+                              sl,   // ust (m_station)
+                              (int)round((*metaPrimitiveIt).phi*65536./0.8), // uphi (_phiAngle)
+                              (int)round((*metaPrimitiveIt).phiB*2048./1.4), // uphib (m_phiBending)
+                              (*metaPrimitiveIt).quality,  // uqua (m_qualityCode)
+                              (*metaPrimitiveIt).index,  // uind (m_segmentIndex)
+                              (int)round((*metaPrimitiveIt).t0)-shift_back*25,  // ut0 (m_t0Segment)
+                              (int)round((*metaPrimitiveIt).chi2*1000000),  // uchi2 (m_chi2Segment)
+                              (*metaPrimitiveIt).rpcFlag    // urpc (m_rpcFlag)
+                              ));
       }
     }
 
     // Storing RPC hits that were not used elsewhere
     if(p2_df == 2 && useRPC) {
-        for (auto rpc_dt_digi = rpc_integrator->rpcRecHits_translated.begin(); rpc_dt_digi != rpc_integrator->rpcRecHits_translated.end(); rpc_dt_digi++) {
-            outP2Ph.push_back(*rpc_dt_digi);
-        }
+      for (auto rpc_dt_digi = rpc_integrator->rpcRecHits_translated.begin(); rpc_dt_digi != rpc_integrator->rpcRecHits_translated.end(); rpc_dt_digi++) {
+        outP2Ph.push_back(*rpc_dt_digi);
+      }
     }
 
     if(p2_df==2){
@@ -438,143 +454,202 @@ void DTTrigPhase2Prod::endRun(edm::Run const& iRun, const edm::EventSetup& iEven
 };
 
 
-
 bool DTTrigPhase2Prod::outer(metaPrimitive mp){
-    int counter = (mp.wi5!=-1)+(mp.wi6!=-1)+(mp.wi7!=-1)+(mp.wi8!=-1);
-    if (counter > 2) return true;
-    else return false;
+  int counter = (mp.wi5!=-1)+(mp.wi6!=-1)+(mp.wi7!=-1)+(mp.wi8!=-1);
+  if (counter > 2) return true;
+  else return false;
 }
+
 
 bool DTTrigPhase2Prod::inner(metaPrimitive mp){
-    int counter = (mp.wi1!=-1)+(mp.wi2!=-1)+(mp.wi3!=-1)+(mp.wi4!=-1);
-    if (counter > 2) return true;
-    else return false;
+  int counter = (mp.wi1!=-1)+(mp.wi2!=-1)+(mp.wi3!=-1)+(mp.wi4!=-1);
+  if (counter > 2) return true;
+  else return false;
 }
+
 
 bool DTTrigPhase2Prod::hasPosRF(int wh,int sec){
-    return  wh>0 || (wh==0 && sec%4>1);
+  return  wh>0 || (wh==0 && sec%4>1);
 }
 
+
 void DTTrigPhase2Prod::printmP(metaPrimitive mP){
-    DTSuperLayerId slId(mP.rawId);
-    std::cout<<slId<<"\t"
-             <<" "<<setw(2)<<left<<mP.wi1
-             <<" "<<setw(2)<<left<<mP.wi2
-             <<" "<<setw(2)<<left<<mP.wi3
-             <<" "<<setw(2)<<left<<mP.wi4
-             <<" "<<setw(5)<<left<<mP.tdc1
-             <<" "<<setw(5)<<left<<mP.tdc2
-             <<" "<<setw(5)<<left<<mP.tdc3
-             <<" "<<setw(5)<<left<<mP.tdc4
-             <<" "<<setw(10)<<right<<mP.x
-             <<" "<<setw(9)<<left<<mP.tanPhi
-             <<" "<<setw(5)<<left<<mP.t0
-             <<" "<<setw(13)<<left<<mP.chi2
-             <<" r:"<<rango(mP);
+  DTSuperLayerId slId(mP.rawId);
+  std::cout<<slId<<"\t"
+            <<" "<<setw(2)<<left<<mP.wi1
+            <<" "<<setw(2)<<left<<mP.wi2
+            <<" "<<setw(2)<<left<<mP.wi3
+            <<" "<<setw(2)<<left<<mP.wi4
+            <<" "<<setw(5)<<left<<mP.tdc1
+            <<" "<<setw(5)<<left<<mP.tdc2
+            <<" "<<setw(5)<<left<<mP.tdc3
+            <<" "<<setw(5)<<left<<mP.tdc4
+            <<" "<<setw(10)<<right<<mP.x
+            <<" "<<setw(9)<<left<<mP.tanPhi
+            <<" "<<setw(5)<<left<<mP.t0
+            <<" "<<setw(13)<<left<<mP.chi2
+            <<" r:"<<rango(mP);
 }
 
 void DTTrigPhase2Prod::printmPC(metaPrimitive mP){
   DTChamberId ChId(mP.rawId);
   std::cout<<ChId<<"\t"
-             <<" "<<setw(2)<<left<<mP.wi1
-             <<" "<<setw(2)<<left<<mP.wi2
-             <<" "<<setw(2)<<left<<mP.wi3
-             <<" "<<setw(2)<<left<<mP.wi4
-             <<" "<<setw(2)<<left<<mP.wi5
-             <<" "<<setw(2)<<left<<mP.wi6
-             <<" "<<setw(2)<<left<<mP.wi7
-             <<" "<<setw(2)<<left<<mP.wi8
-             <<" "<<setw(5)<<left<<mP.tdc1
-             <<" "<<setw(5)<<left<<mP.tdc2
-             <<" "<<setw(5)<<left<<mP.tdc3
-             <<" "<<setw(5)<<left<<mP.tdc4
-             <<" "<<setw(5)<<left<<mP.tdc5
-             <<" "<<setw(5)<<left<<mP.tdc6
-             <<" "<<setw(5)<<left<<mP.tdc7
-             <<" "<<setw(5)<<left<<mP.tdc8
-             <<" "<<setw(2)<<left<<mP.lat1
-             <<" "<<setw(2)<<left<<mP.lat2
-             <<" "<<setw(2)<<left<<mP.lat3
-             <<" "<<setw(2)<<left<<mP.lat4
-             <<" "<<setw(2)<<left<<mP.lat5
-             <<" "<<setw(2)<<left<<mP.lat6
-             <<" "<<setw(2)<<left<<mP.lat7
-             <<" "<<setw(2)<<left<<mP.lat8
-             <<" "<<setw(10)<<right<<mP.x
-             <<" "<<setw(9)<<left<<mP.tanPhi
-             <<" "<<setw(5)<<left<<mP.t0
-             <<" "<<setw(13)<<left<<mP.chi2
-             <<" r:"<<rango(mP);
+            <<" "<<setw(2)<<left<<mP.wi1
+            <<" "<<setw(2)<<left<<mP.wi2
+            <<" "<<setw(2)<<left<<mP.wi3
+            <<" "<<setw(2)<<left<<mP.wi4
+            <<" "<<setw(2)<<left<<mP.wi5
+            <<" "<<setw(2)<<left<<mP.wi6
+            <<" "<<setw(2)<<left<<mP.wi7
+            <<" "<<setw(2)<<left<<mP.wi8
+            <<" "<<setw(5)<<left<<mP.tdc1
+            <<" "<<setw(5)<<left<<mP.tdc2
+            <<" "<<setw(5)<<left<<mP.tdc3
+            <<" "<<setw(5)<<left<<mP.tdc4
+            <<" "<<setw(5)<<left<<mP.tdc5
+            <<" "<<setw(5)<<left<<mP.tdc6
+            <<" "<<setw(5)<<left<<mP.tdc7
+            <<" "<<setw(5)<<left<<mP.tdc8
+            <<" "<<setw(2)<<left<<mP.lat1
+            <<" "<<setw(2)<<left<<mP.lat2
+            <<" "<<setw(2)<<left<<mP.lat3
+            <<" "<<setw(2)<<left<<mP.lat4
+            <<" "<<setw(2)<<left<<mP.lat5
+            <<" "<<setw(2)<<left<<mP.lat6
+            <<" "<<setw(2)<<left<<mP.lat7
+            <<" "<<setw(2)<<left<<mP.lat8
+            <<" "<<setw(10)<<right<<mP.x
+            <<" "<<setw(9)<<left<<mP.tanPhi
+            <<" "<<setw(5)<<left<<mP.t0
+            <<" "<<setw(13)<<left<<mP.chi2
+            <<" r:"<<rango(mP);
 }
+
 
 int DTTrigPhase2Prod::rango(metaPrimitive mp) {
-    if(mp.quality==1 or mp.quality==2) return 3;
-    if(mp.quality==3 or mp.quality==4) return 4;
-    return mp.quality;
+  if(mp.quality==1 or mp.quality==2) return 3;
+  if(mp.quality==3 or mp.quality==4) return 4;
+  return mp.quality;
 }
-
 
 
 void  DTTrigPhase2Prod::assignIndex(std::vector<metaPrimitive> &inMPaths)
 {
-    std::map <int, std::vector<metaPrimitive> >  primsPerBX; 
-    for (auto & metaPrimitive : inMPaths){
-      int BX = round(metaPrimitive.t0 / 25.);
-      primsPerBX[BX].push_back(metaPrimitive);
-    } 
-    inMPaths.clear();
-    for (auto & prims : primsPerBX) {
-      assignIndexPerBX (prims.second);
-      for (auto & primitive : prims.second ) inMPaths.push_back(primitive);
-    }
-
-
+  std::map <int, std::vector<metaPrimitive> >  primsPerBX;
+  for (auto & metaPrimitive : inMPaths){
+    int BX = round(metaPrimitive.t0 / 25.);
+    primsPerBX[BX].push_back(metaPrimitive);
+  }
+  inMPaths.clear();
+  for (auto & prims : primsPerBX) {
+    assignIndexPerBX (prims.second);
+    for (auto & primitive : prims.second ) inMPaths.push_back(primitive);
+  }
 }
+
+
 void  DTTrigPhase2Prod::assignIndexPerBX(std::vector<metaPrimitive> &inMPaths)
 {
-    // First we asociate a new index to the metaprimitive depending on quality or phiB; 
-    uint32_t rawId = -1; 
-    int numP = -1;
-    for (auto metaPrimitiveIt = inMPaths.begin(); metaPrimitiveIt != inMPaths.end(); ++metaPrimitiveIt){
-      numP++;
-      rawId = (*metaPrimitiveIt).rawId;   
-      int iOrder = assignQualityOrder((*metaPrimitiveIt));
-      int inf = 0;
-      int numP2 = -1;  
-      for (auto metaPrimitiveItN = inMPaths.begin(); metaPrimitiveItN != inMPaths.end(); ++metaPrimitiveItN){
-        int nOrder = assignQualityOrder((*metaPrimitiveItN));    
-        numP2++;
-	if (rawId != (*metaPrimitiveItN).rawId) continue; 
-	if (numP2 == numP) {
-	  (*metaPrimitiveIt).index = inf; 
-	  break;  
-	} else if (iOrder < nOrder) {
-	  inf++;
-	} else if (iOrder > nOrder) {
-	  (*metaPrimitiveItN).index++;
-	} else if (iOrder == nOrder) {
-	  if (fabs((*metaPrimitiveIt).phiB) >= fabs((*metaPrimitiveItN).phiB) ){
-	    inf++;
-	  } else if (fabs((*metaPrimitiveIt).phiB) < fabs((*metaPrimitiveItN).phiB) ){
-	    (*metaPrimitiveItN).index++;
-	  }
-        }	
-      } // ending second for
-    } // ending first for
-}
-
-int DTTrigPhase2Prod::assignQualityOrder(metaPrimitive mP)
-{
-    if (mP.quality == 9) return 9;
-    if (mP.quality == 8) return 8;
-    if (mP.quality == 7) return 6;
-    if (mP.quality == 6) return 7;
-    if (mP.quality == 5) return 3;
-    if (mP.quality == 4) return 5;
-    if (mP.quality == 3) return 4;
-    if (mP.quality == 2) return 2;
-    if (mP.quality == 1) return 1;
-    return -1; 
+  // First we asociate a new index to the metaprimitive depending on quality or phiB;
+  uint32_t rawId = -1;
+  int numP = -1;
+  for (auto metaPrimitiveIt = inMPaths.begin(); metaPrimitiveIt != inMPaths.end(); ++metaPrimitiveIt){
+    numP++;
+    rawId = (*metaPrimitiveIt).rawId;
+    int iOrder = assignQualityOrder((*metaPrimitiveIt));
+    int inf = 0;
+    int numP2 = -1;
+    for (auto metaPrimitiveItN = inMPaths.begin(); metaPrimitiveItN != inMPaths.end(); ++metaPrimitiveItN){
+      int nOrder = assignQualityOrder((*metaPrimitiveItN));
+      numP2++;
+      if (rawId != (*metaPrimitiveItN).rawId) continue;
+      if (numP2 == numP) {
+        (*metaPrimitiveIt).index = inf;
+        break;
+      } else if (iOrder < nOrder) {
+        inf++;
+      } else if (iOrder > nOrder) {
+        (*metaPrimitiveItN).index++;
+      } else if (iOrder == nOrder) {
+        if (fabs((*metaPrimitiveIt).phiB) >= fabs((*metaPrimitiveItN).phiB) ){
+          inf++;
+        } else if (fabs((*metaPrimitiveIt).phiB) < fabs((*metaPrimitiveItN).phiB) ){
+          (*metaPrimitiveItN).index++;
+        }
+      }
+    } // ending second for
+  } // ending first for
 }
 
 
+int DTTrigPhase2Prod::assignQualityOrder(metaPrimitive mP) {
+  if (mP.quality == 9) return 9;
+  if (mP.quality == 8) return 8;
+  if (mP.quality == 7) return 6;
+  if (mP.quality == 6) return 7;
+  if (mP.quality == 5) return 3;
+  if (mP.quality == 4) return 5;
+  if (mP.quality == 3) return 4;
+  if (mP.quality == 2) return 2;
+  if (mP.quality == 1) return 1;
+  return -1;
+}
+
+
+std::vector<DTDigiCollection*> DTTrigPhase2Prod::distribDigis(std::queue<std::pair<DTLayerId*, DTDigi*>>& inQ) {
+//   cout << "Declarando..." << endl;
+  std::vector<std::queue<std::pair<DTLayerId*, DTDigi*>>*> tmpVector; tmpVector.clear();
+  std::vector<DTDigiCollection*> collVector; collVector.clear();
+//   cout << "Empezando while..." << endl;
+  while (!inQ.empty()) {
+    // Possible enhancement: build a supercell class that automatically encloses this code, i.e. that comprises
+    // a entire supercell within it.
+//     cout << "Llamando a processDigi..." << endl;
+    processDigi(inQ, tmpVector);
+  }
+//   cout << "Terminado while" << endl;
+
+//   cout << "Comenzando for del vector..." << endl;
+  for (auto & sQ : tmpVector) {
+    DTDigiCollection* tmpColl = new DTDigiCollection();
+    while (!sQ->empty()) {
+      tmpColl->insertDigi(*(sQ->front().first), *(sQ->front().second));
+      sQ->pop();
+    }
+    collVector.push_back(std::move(tmpColl));
+  }
+  return collVector;
+}
+
+
+void DTTrigPhase2Prod::processDigi(std::queue<std::pair<DTLayerId*, DTDigi*>>& inQ, std::vector<std::queue<std::pair<DTLayerId*, DTDigi*>>*>& vec) {
+  Bool_t classified = false;
+  if (vec.size() != 0) {
+//     cout << "El tamaño del vector no es nulo. En particular, es: " << vec.size() << ". Comenzando for sobre las distintas colas" << endl;
+    for (auto & sC : vec) { // Conditions for entering a super cell. TODO: add geometric requirements.
+//       cout << "comprobando uno de los elementos. Tiempo + 400: " << sC->front().second->time() + 400 << ", tiempo del otro: " << inQ.front().second->time() << endl;
+      if ((sC->front().second->time() + 400) > inQ.front().second->time()) { // Time requirement
+        if (TMath::Abs(sC->front().second->wire() - inQ.front().second->wire()) <= 10) { // Spatial requirement
+//           cout << "¡aceptado! Tamaño antes de la cola central: " << inQ.size() << " tamaño antes de la cola donde se meterá: " << sC->size() << endl;
+          sC->push(std::move(inQ.front()));
+//           cout << "¡aceptado! Tamaño luego de la cola central: " << inQ.size() << " tamaño luego de la cola donde se meterá: " << sC->size() << endl;
+          classified = true;
+        }
+      }
+    }
+  }
+  if (classified) {
+    inQ.pop();
+    return;
+  }
+//   cout << "El tamaño del vector es nulo, o no hemos podido meter al digi en ninguna cola. Declarando nueva cola..." << endl;
+  std::queue<std::pair<DTLayerId*, DTDigi*>>* newQueue = new std::queue<std::pair<DTLayerId*, DTDigi*>>;
+//   cout << "Introduciendo digi..." << endl;
+  std::pair<DTLayerId*, DTDigi*>* tmpPair = new std::pair<DTLayerId*, DTDigi*>;
+  tmpPair =  std::move(&inQ.front());
+  newQueue->push(*tmpPair);
+  inQ.pop();
+//   cout << "Introduciendo cola nel vector..." << endl;
+  vec.push_back(std::move(newQueue));
+  return;
+}

--- a/L1Trigger/DTPhase2Trigger/src/HoughGrouping.cc
+++ b/L1Trigger/DTPhase2Trigger/src/HoughGrouping.cc
@@ -4,6 +4,29 @@ using namespace std;
 using namespace edm;
 using namespace cms;
 
+
+struct {
+  Bool_t operator()(std::tuple<UShort_t, Bool_t*, Bool_t*, UShort_t, Double_t*, DTPrimitive*> a, std::tuple<UShort_t, Bool_t*, Bool_t*, UShort_t, Double_t*, DTPrimitive*> b) const {
+
+    UShort_t sumhqa    = 0; UShort_t sumhqb    = 0;
+    UShort_t sumlqa    = 0; UShort_t sumlqb    = 0;
+    Double_t sumdista  = 0; Double_t sumdistb  = 0;
+
+    for (UShort_t lay = 0; lay < 8; lay++) {
+      sumhqa   += (UShort_t)get<1>(a)[lay]; sumhqb   += (UShort_t)get<1>(b)[lay];
+      sumlqa   += (UShort_t)get<2>(a)[lay]; sumlqb   += (UShort_t)get<2>(b)[lay];
+      sumdista += get<4>(a)[lay];           sumdistb += get<4>(b)[lay];
+    }
+
+    if      (get<0>(a) != get<0>(b)) return (get<0>(a) > get<0>(b)); // number of layers with hits
+    else if (sumhqa    != sumhqb)    return (sumhqa    > sumhqb);    // number of hq hits
+    else if (sumlqa    != sumlqb)    return (sumlqa    > sumlqb);    // number of lq hits
+    else if (get<3>(a) != get<3>(b)) return (get<3>(a) < get<3>(b)); // abs. diff. between SL1 & SL3 hits
+    else                             return (sumdista < sumdistb);   // abs. dist. to digis
+  }
+} HoughOrdering;
+
+
 // ============================================================================
 // Constructors and destructor
 // ============================================================================
@@ -710,8 +733,14 @@ void HoughGrouping::OrderAndFilter(std::vector<std::tuple<UShort_t, Bool_t*, Boo
     UShort_t tmplowfill = 0; UShort_t tmpupfill = 0;
     for (UShort_t lay = 0; lay < 8; lay++) {
       ptrPrimitive[lay] = new DTPrimitive(get<5>(invector.at(i))[lay]);
-      if (debug) cout << "\nHoughGrouping::OrderAndFilter - cameraid: " << ptrPrimitive[lay]->getCameraId() << endl;
-      if (debug) cout << "HoughGrouping::OrderAndFilter - channelid: "  << ptrPrimitive[lay]->getChannelId() << endl;
+      if (debug) {
+        cout << "\nHoughGrouping::OrderAndFilter - cameraid: "       << ptrPrimitive[lay]->getCameraId() << endl;
+        cout << "HoughGrouping::OrderAndFilter - channelid (GOOD): " << ptrPrimitive[lay]->getChannelId() << endl;
+        cout << "HoughGrouping::OrderAndFilter - channelid (AM):   " << ptrPrimitive[lay]->getChannelId() - 1 << endl;
+      }
+      // Fixing channel ID to AM conventions...
+      if (ptrPrimitive[lay]->getChannelId() != -1) ptrPrimitive[lay]->setChannelId(ptrPrimitive[lay]->getChannelId() - 1);
+
       if (ptrPrimitive[lay]->getCameraId() > 0) {
         if (lay < 4) tmplowfill++;
         else         tmpupfill++;

--- a/L1Trigger/DTPhase2Trigger/src/HoughGrouping.cc
+++ b/L1Trigger/DTPhase2Trigger/src/HoughGrouping.cc
@@ -169,8 +169,8 @@ void HoughGrouping::run(edm::Event& iEvent, const edm::EventSetup& iEventSetup, 
       
       if (debug) {
         cout << "HoughGrouping::run - X position of the cell (chamber frame of reference): " << wirePosInChamber.x() << endl;
-        cout << "HoughGrouping::run - Y position of the cell (chamber frame of reference)" << wirePosInChamber.y() << endl;
-        cout << "HoughGrouping::run - Z position of the cell (chamber frame of reference)" << wirePosInChamber.z() << endl;
+        cout << "HoughGrouping::run - Y position of the cell (chamber frame of reference): " << wirePosInChamber.y() << endl;
+        cout << "HoughGrouping::run - Z position of the cell (chamber frame of reference): " << wirePosInChamber.z() << endl;
       }
       
       hitvec.push_back( {wirePosInChamber.x() - 1.05, wirePosInChamber.z()} );

--- a/L1Trigger/DTPhase2Trigger/src/MuonPathAnalyzerInChamber.cc
+++ b/L1Trigger/DTPhase2Trigger/src/MuonPathAnalyzerInChamber.cc
@@ -151,7 +151,7 @@ void MuonPathAnalyzerInChamber::analyze(MuonPath *inMPath,std::vector<MuonPath*>
         present_layer[ii]=1;
       }
     }
-
+    
     while (NTotalHits >= minHits4Fit){
       mPath->setChiSq(0); 
       calculateFitParameters(mPath,lateralities[i], present_layer);
@@ -162,7 +162,9 @@ void MuonPathAnalyzerInChamber::analyze(MuonPath *inMPath,std::vector<MuonPath*>
     
 
     evaluateQuality(mPath);
+    
     if ( mPath->getQuality() < minQuality ) continue;
+    
    /* 
     int selected_Id=0;
     for (int i=0; i<mPath->getNPrimitives(); i++) {
@@ -192,7 +194,6 @@ void MuonPathAnalyzerInChamber::analyze(MuonPath *inMPath,std::vector<MuonPath*>
     
     double jm_x=(mPath->getHorizPos()/10.)+shiftinfo[wireId.rawId()]; 
 */   
-
     double z=0;
     double jm_x=(mPath->getHorizPos());
     int selected_Id=0;
@@ -222,7 +223,6 @@ void MuonPathAnalyzerInChamber::analyze(MuonPath *inMPath,std::vector<MuonPath*>
       best_chi2 = mPath->getChiSq();
     }
   }
-  
   if (mpAux!=NULL){ 
     outMPath.push_back(std::move(mpAux));
     if (debug) std::cout<<"DTp2:analize \t\t\t\t\t Laterality "<< bestI << " is the one with smaller chi2"<<std::endl;
@@ -503,7 +503,7 @@ void MuonPathAnalyzerInChamber::calculateFitParameters(MuonPath *mpath, TLateral
     rectdriftvdrift[lay]= tTDCvdrift[lay]- rect0vdrift/1000;
     if (debug) cout << rectdriftvdrift[lay] << endl; 
     recres[lay]=xhit[lay]-zwire[lay]*recslope-b[lay]*recpos-(-1+2*laterality[lay])*rect0vdrift;
-    // if (debug) cout << recres[lay] << endl;  
+     //if (debug) cout <<"Pr14 "<< recres[lay] << endl;  
     if ((present_layer[lay]==1)&&(rectdriftvdrift[lay] <-0.1)){
       sign_tdriftvdrift=-1;
       if (-0.1 - rectdriftvdrift[lay] > maxDif) {
@@ -545,9 +545,9 @@ void MuonPathAnalyzerInChamber::calculateFitParameters(MuonPath *mpath, TLateral
     mpath->setHorizPos(recpos/10000);
     mpath->setChiSq(recchi2/100000000);
     setLateralitiesInMP(mpath,laterality);
-    
     if(debug) cout << "In fitPerLat " << "t0 " <<  mpath->getBxTimeValue() <<" slope " << mpath->getTanPhi() <<" pos "<< mpath->getHorizPos() <<" chi2 "<< mpath->getChiSq() << " rawId " << mpath->getRawId() << endl;
   }
+  //std::cout<<"Pr 1 " <<mpath->getChiSq() << endl;
   
 }
 /**
@@ -560,7 +560,7 @@ void MuonPathAnalyzerInChamber::evaluateQuality(MuonPath *mPath) {
   // Por defecto.
   mPath->setQuality(NOPATH);
   
-  if      (mPath->getNPrimitivesUp() == 4 && mPath->getNPrimitivesDown() == 4) {
+  if (mPath->getNPrimitivesUp() >= 4 && mPath->getNPrimitivesDown() >= 4) {
     mPath->setQuality(HIGHHIGHQ);
   }
   else if ((mPath->getNPrimitivesUp() == 4 && mPath->getNPrimitivesDown() == 3) || 
@@ -568,27 +568,27 @@ void MuonPathAnalyzerInChamber::evaluateQuality(MuonPath *mPath) {
 	   ) {
     mPath->setQuality(HIGHLOWQ);
   } 
-  else if ((mPath->getNPrimitivesUp() == 4 && mPath->getNPrimitivesDown() <= 2) || 
-	   (mPath->getNPrimitivesUp() <= 2 && mPath->getNPrimitivesDown() == 4)
+  else if ((mPath->getNPrimitivesUp() == 4 && mPath->getNPrimitivesDown() <= 2 && mPath->getNPrimitivesDown()>0) || 
+	   (mPath->getNPrimitivesUp() <= 2 && mPath->getNPrimitivesUp()>0 && mPath->getNPrimitivesDown() == 4)
 	   ){
-    mPath->setQuality(CHIGHQ);
+    mPath->setQuality(CHIGHQ); //Falta añadir que el 4+0 no esta aqui
   }
   else if ((mPath->getNPrimitivesUp() == 3 && mPath->getNPrimitivesDown() == 3)
 	   ){
     mPath->setQuality(LOWLOWQ);
   }
-  else if ((mPath->getNPrimitivesUp() == 3 && mPath->getNPrimitivesDown() <= 2) || 
-	   (mPath->getNPrimitivesUp() <= 2 && mPath->getNPrimitivesDown() == 3) || 
+  else if ((mPath->getNPrimitivesUp() == 3 && mPath->getNPrimitivesDown() <= 2 && mPath->getNPrimitivesDown()>0) || 
+	   (mPath->getNPrimitivesUp() <= 2 &&  mPath->getNPrimitivesUp()>0 && mPath->getNPrimitivesDown() == 3) || 
 	   (mPath->getNPrimitivesUp() == 2 && mPath->getNPrimitivesDown() == 2)	   
 	   ){
-    mPath->setQuality(CLOWQ);
-  }
-  else if (mPath->getNPrimitivesUp() == 4 || mPath->getNPrimitivesDown() == 4) {
+    mPath->setQuality(CLOWQ); //Falta añadir que el 3+0 no esta aqui
+  }  
+  else if (mPath->getNPrimitivesUp() >= 4 || mPath->getNPrimitivesDown() >= 4) {
     mPath->setQuality(HIGHQ);    
   }
   else if (mPath->getNPrimitivesUp() == 3 || mPath->getNPrimitivesDown() == 3) {
     mPath->setQuality(LOWQ);    
   }
-  
+  //std::cout<<mPath->getNPrimitivesUp()<<'+'<<mPath->getNPrimitivesDown()<<'='<<mPath->getQuality()<<endl;
 }
 


### PR DESCRIPTION
>**A check w/o buffering and w/ the previous code using a small set of data events has been done and no differences have been found**

- First version of buffering implemented, only checked with data, a small addition to the code is surely needed for MC.
- After seeing lots of spaces + tabs + various indentation schemes, a clean of the main cc & header has been done, establishing what seems to be the standard in the rest of CMSSW code: 2 spaces per indentation level, no tabs.
- Added various parameters to python config file to control the buffering.
- Other minor changes and bugfixes for hough grouping.